### PR TITLE
Go 1.18: rewrite `interface{}` to `any`

### DIFF
--- a/components/common-go/analytics/analytics.go
+++ b/components/common-go/analytics/analytics.go
@@ -22,7 +22,7 @@ type Identity struct {
 type IdentifyMessage struct {
 	Identity
 
-	Traits    map[string]interface{}
+	Traits    map[string]any
 	Timestamp time.Time
 }
 
@@ -31,7 +31,7 @@ type TrackMessage struct {
 	Identity
 
 	Event      string
-	Properties map[string]interface{}
+	Properties map[string]any
 	Timestamp  time.Time
 }
 

--- a/components/common-go/grpc/ratelimit.go
+++ b/components/common-go/grpc/ratelimit.go
@@ -21,7 +21,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 )
 
-type keyFunc func(req interface{}) (string, error)
+type keyFunc func(req any) (string, error)
 
 // RateLimit configures the reate limit for a function
 type RateLimit struct {
@@ -78,7 +78,7 @@ func NewRatelimitingInterceptor(f map[string]RateLimit) RatelimitingInterceptor 
 }
 
 func fieldAccessKey(key string) keyFunc {
-	return func(req interface{}) (string, error) {
+	return func(req any) (string, error) {
 		msg, ok := req.(proto.Message)
 		if !ok {
 			return "", status.Errorf(codes.Internal, "request was not a protobuf message")
@@ -157,7 +157,7 @@ type ratelimitedFunction struct {
 
 // UnaryInterceptor creates a unary interceptor that implements the rate limiting
 func (r RatelimitingInterceptor) UnaryInterceptor() grpc.UnaryServerInterceptor {
-	return func(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (resp interface{}, err error) {
+	return func(ctx context.Context, req any, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (resp any, err error) {
 		f, ok := r.functions[info.FullMethod]
 		if !ok {
 			return handler(ctx, req)

--- a/components/common-go/log/export.go
+++ b/components/common-go/log/export.go
@@ -26,7 +26,7 @@ func WithContext(ctx context.Context) *logrus.Entry {
 //
 // Note that it doesn't log until you call Debug, Print, Info, Warn, Fatal
 // or Panic on the Entry it returns.
-func WithField(key string, value interface{}) *logrus.Entry {
+func WithField(key string, value any) *logrus.Entry {
 	return Log.WithField(key, value)
 }
 
@@ -50,136 +50,136 @@ func WithTime(t time.Time) *logrus.Entry {
 }
 
 // Trace logs a message at level Trace on the standard logger.
-func Trace(args ...interface{}) {
+func Trace(args ...any) {
 	Log.Trace(args...)
 }
 
 // Debug logs a message at level Debug on the standard logger.
-func Debug(args ...interface{}) {
+func Debug(args ...any) {
 	Log.Debug(args...)
 }
 
 // Print logs a message at level Info on the standard logger.
-func Print(args ...interface{}) {
+func Print(args ...any) {
 	Log.Print(args...)
 }
 
 // Info logs a message at level Info on the standard logger.
-func Info(args ...interface{}) {
+func Info(args ...any) {
 	Log.Info(args...)
 }
 
 // Warn logs a message at level Warn on the standard logger.
-func Warn(args ...interface{}) {
+func Warn(args ...any) {
 	Log.Warn(args...)
 }
 
 // Warning logs a message at level Warn on the standard logger.
-func Warning(args ...interface{}) {
+func Warning(args ...any) {
 	Log.Warning(args...)
 }
 
 // Error logs a message at level Error on the standard logger.
-func Error(args ...interface{}) {
+func Error(args ...any) {
 	Log.Error(args...)
 }
 
 // Panic logs a message at level Panic on the standard logger.
-func Panic(args ...interface{}) {
+func Panic(args ...any) {
 	Log.Panic(args...)
 }
 
 // Fatal logs a message at level Fatal on the standard logger then the process will exit with status set to 1.
-func Fatal(args ...interface{}) {
+func Fatal(args ...any) {
 	Log.Fatal(args...)
 }
 
 // Tracef logs a message at level Trace on the standard logger.
-func Tracef(format string, args ...interface{}) {
+func Tracef(format string, args ...any) {
 	Log.Tracef(format, args...)
 }
 
 // Debugf logs a message at level Debug on the standard logger.
-func Debugf(format string, args ...interface{}) {
+func Debugf(format string, args ...any) {
 	Log.Debugf(format, args...)
 }
 
 // Printf logs a message at level Info on the standard logger.
-func Printf(format string, args ...interface{}) {
+func Printf(format string, args ...any) {
 	Log.Printf(format, args...)
 }
 
 // Infof logs a message at level Info on the standard logger.
-func Infof(format string, args ...interface{}) {
+func Infof(format string, args ...any) {
 	Log.Infof(format, args...)
 }
 
 // Warnf logs a message at level Warn on the standard logger.
-func Warnf(format string, args ...interface{}) {
+func Warnf(format string, args ...any) {
 	Log.Warnf(format, args...)
 }
 
 // Warningf logs a message at level Warn on the standard logger.
-func Warningf(format string, args ...interface{}) {
+func Warningf(format string, args ...any) {
 	Log.Warningf(format, args...)
 }
 
 // Errorf logs a message at level Error on the standard logger.
-func Errorf(format string, args ...interface{}) {
+func Errorf(format string, args ...any) {
 	Log.Errorf(format, args...)
 }
 
 // Panicf logs a message at level Panic on the standard logger.
-func Panicf(format string, args ...interface{}) {
+func Panicf(format string, args ...any) {
 	Log.Panicf(format, args...)
 }
 
 // Fatalf logs a message at level Fatal on the standard logger then the process will exit with status set to 1.
-func Fatalf(format string, args ...interface{}) {
+func Fatalf(format string, args ...any) {
 	Log.Fatalf(format, args...)
 }
 
 // Traceln logs a message at level Trace on the standard logger.
-func Traceln(args ...interface{}) {
+func Traceln(args ...any) {
 	Log.Traceln(args...)
 }
 
 // Debugln logs a message at level Debug on the standard logger.
-func Debugln(args ...interface{}) {
+func Debugln(args ...any) {
 	Log.Debugln(args...)
 }
 
 // Println logs a message at level Info on the standard logger.
-func Println(args ...interface{}) {
+func Println(args ...any) {
 	Log.Println(args...)
 }
 
 // Infoln logs a message at level Info on the standard logger.
-func Infoln(args ...interface{}) {
+func Infoln(args ...any) {
 	Log.Infoln(args...)
 }
 
 // Warnln logs a message at level Warn on the standard logger.
-func Warnln(args ...interface{}) {
+func Warnln(args ...any) {
 	Log.Warnln(args...)
 }
 
 // Warningln logs a message at level Warn on the standard logger.
-func Warningln(args ...interface{}) {
+func Warningln(args ...any) {
 	Log.Warningln(args...)
 }
 
 // Errorln logs a message at level Error on the standard logger.
-func Errorln(args ...interface{}) {
+func Errorln(args ...any) {
 	Log.Errorln(args...)
 }
 
 // Panicln logs a message at level Panic on the standard logger.
-func Panicln(args ...interface{}) {
+func Panicln(args ...any) {
 	Log.Panicln(args...)
 }
 
 // Fatalln logs a message at level Fatal on the standard logger then the process will exit with status set to 1.
-func Fatalln(args ...interface{}) {
+func Fatalln(args ...any) {
 	Log.Fatalln(args...)
 }

--- a/components/common-go/log/redact.go
+++ b/components/common-go/log/redact.go
@@ -21,7 +21,7 @@ var (
 
 // RedactJSON removes sensitive data from JSON structures
 func RedactJSON(data []byte) (res []byte, err error) {
-	var jsonBlob interface{}
+	var jsonBlob any
 	err = json.Unmarshal(data, &jsonBlob)
 	if err != nil {
 		return data, err
@@ -32,14 +32,14 @@ func RedactJSON(data []byte) (res []byte, err error) {
 }
 
 // blatently copied from https://github.com/cloudfoundry/lager/blob/master/json_redacter.go#L45
-func redactValue(data *interface{}) interface{} {
+func redactValue(data *any) any {
 	if data == nil {
 		return data
 	}
 
-	if a, ok := (*data).([]interface{}); ok {
+	if a, ok := (*data).([]any); ok {
 		redactArray(&a)
-	} else if m, ok := (*data).(map[string]interface{}); ok {
+	} else if m, ok := (*data).(map[string]any); ok {
 		redactObject(&m)
 	} else if s, ok := (*data).(string); ok {
 		for _, prohibited := range redactedFields {
@@ -52,13 +52,13 @@ func redactValue(data *interface{}) interface{} {
 	return (*data)
 }
 
-func redactArray(data *[]interface{}) {
+func redactArray(data *[]any) {
 	for i := range *data {
 		redactValue(&((*data)[i]))
 	}
 }
 
-func redactObject(data *map[string]interface{}) {
+func redactObject(data *map[string]any) {
 	for k, v := range *data {
 		for _, prohibited := range redactedFields {
 			if strings.Contains(strings.ToLower(fmt.Sprintf("%v", k)), prohibited) {

--- a/components/common-go/testing/fixtures.go
+++ b/components/common-go/testing/fixtures.go
@@ -31,12 +31,12 @@ type FixtureTest struct {
 	Path     string
 	GoldPath func(path string) string
 	Test     FixtureTestFunc
-	Fixture  func() interface{}
-	Gold     func() interface{}
+	Fixture  func() any
+	Gold     func() any
 }
 
 // FixtureTestFunc implements the actual fixture test
-type FixtureTestFunc func(t *testing.T, fixture interface{}) interface{}
+type FixtureTestFunc func(t *testing.T, fixture any) any
 
 // Run executes the fixture test - do not forget to call this one
 func (ft *FixtureTest) Run() {

--- a/components/common-go/util/duration.go
+++ b/components/common-go/util/duration.go
@@ -16,7 +16,7 @@ type Duration time.Duration
 
 // UnmarshalJSON parses the duration to a time.Duration
 func (d *Duration) UnmarshalJSON(b []byte) error {
-	var v interface{}
+	var v any
 	if err := json.Unmarshal(b, &v); err != nil {
 		return err
 	}

--- a/components/content-service-api/go/blobs.pb.go
+++ b/components/content-service-api/go/blobs.pb.go
@@ -437,7 +437,7 @@ func file_blobs_proto_rawDescGZIP() []byte {
 }
 
 var file_blobs_proto_msgTypes = make([]protoimpl.MessageInfo, 6)
-var file_blobs_proto_goTypes = []interface{}{
+var file_blobs_proto_goTypes = []any{
 	(*UploadUrlRequest)(nil),    // 0: contentservice.UploadUrlRequest
 	(*UploadUrlResponse)(nil),   // 1: contentservice.UploadUrlResponse
 	(*DownloadUrlRequest)(nil),  // 2: contentservice.DownloadUrlRequest
@@ -465,7 +465,7 @@ func file_blobs_proto_init() {
 		return
 	}
 	if !protoimpl.UnsafeEnabled {
-		file_blobs_proto_msgTypes[0].Exporter = func(v interface{}, i int) interface{} {
+		file_blobs_proto_msgTypes[0].Exporter = func(v any, i int) any {
 			switch v := v.(*UploadUrlRequest); i {
 			case 0:
 				return &v.state
@@ -477,7 +477,7 @@ func file_blobs_proto_init() {
 				return nil
 			}
 		}
-		file_blobs_proto_msgTypes[1].Exporter = func(v interface{}, i int) interface{} {
+		file_blobs_proto_msgTypes[1].Exporter = func(v any, i int) any {
 			switch v := v.(*UploadUrlResponse); i {
 			case 0:
 				return &v.state
@@ -489,7 +489,7 @@ func file_blobs_proto_init() {
 				return nil
 			}
 		}
-		file_blobs_proto_msgTypes[2].Exporter = func(v interface{}, i int) interface{} {
+		file_blobs_proto_msgTypes[2].Exporter = func(v any, i int) any {
 			switch v := v.(*DownloadUrlRequest); i {
 			case 0:
 				return &v.state
@@ -501,7 +501,7 @@ func file_blobs_proto_init() {
 				return nil
 			}
 		}
-		file_blobs_proto_msgTypes[3].Exporter = func(v interface{}, i int) interface{} {
+		file_blobs_proto_msgTypes[3].Exporter = func(v any, i int) any {
 			switch v := v.(*DownloadUrlResponse); i {
 			case 0:
 				return &v.state
@@ -513,7 +513,7 @@ func file_blobs_proto_init() {
 				return nil
 			}
 		}
-		file_blobs_proto_msgTypes[4].Exporter = func(v interface{}, i int) interface{} {
+		file_blobs_proto_msgTypes[4].Exporter = func(v any, i int) any {
 			switch v := v.(*DeleteRequest); i {
 			case 0:
 				return &v.state
@@ -525,7 +525,7 @@ func file_blobs_proto_init() {
 				return nil
 			}
 		}
-		file_blobs_proto_msgTypes[5].Exporter = func(v interface{}, i int) interface{} {
+		file_blobs_proto_msgTypes[5].Exporter = func(v any, i int) any {
 			switch v := v.(*DeleteResponse); i {
 			case 0:
 				return &v.state
@@ -538,7 +538,7 @@ func file_blobs_proto_init() {
 			}
 		}
 	}
-	file_blobs_proto_msgTypes[4].OneofWrappers = []interface{}{
+	file_blobs_proto_msgTypes[4].OneofWrappers = []any{
 		(*DeleteRequest_Exact)(nil),
 		(*DeleteRequest_Prefix)(nil),
 	}

--- a/components/content-service-api/go/blobs_grpc.pb.go
+++ b/components/content-service-api/go/blobs_grpc.pb.go
@@ -108,7 +108,7 @@ func RegisterBlobServiceServer(s grpc.ServiceRegistrar, srv BlobServiceServer) {
 	s.RegisterService(&BlobService_ServiceDesc, srv)
 }
 
-func _BlobService_UploadUrl_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+func _BlobService_UploadUrl_Handler(srv any, ctx context.Context, dec func(any) error, interceptor grpc.UnaryServerInterceptor) (any, error) {
 	in := new(UploadUrlRequest)
 	if err := dec(in); err != nil {
 		return nil, err
@@ -120,13 +120,13 @@ func _BlobService_UploadUrl_Handler(srv interface{}, ctx context.Context, dec fu
 		Server:     srv,
 		FullMethod: "/contentservice.BlobService/UploadUrl",
 	}
-	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+	handler := func(ctx context.Context, req any) (any, error) {
 		return srv.(BlobServiceServer).UploadUrl(ctx, req.(*UploadUrlRequest))
 	}
 	return interceptor(ctx, in, info, handler)
 }
 
-func _BlobService_DownloadUrl_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+func _BlobService_DownloadUrl_Handler(srv any, ctx context.Context, dec func(any) error, interceptor grpc.UnaryServerInterceptor) (any, error) {
 	in := new(DownloadUrlRequest)
 	if err := dec(in); err != nil {
 		return nil, err
@@ -138,13 +138,13 @@ func _BlobService_DownloadUrl_Handler(srv interface{}, ctx context.Context, dec 
 		Server:     srv,
 		FullMethod: "/contentservice.BlobService/DownloadUrl",
 	}
-	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+	handler := func(ctx context.Context, req any) (any, error) {
 		return srv.(BlobServiceServer).DownloadUrl(ctx, req.(*DownloadUrlRequest))
 	}
 	return interceptor(ctx, in, info, handler)
 }
 
-func _BlobService_Delete_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+func _BlobService_Delete_Handler(srv any, ctx context.Context, dec func(any) error, interceptor grpc.UnaryServerInterceptor) (any, error) {
 	in := new(DeleteRequest)
 	if err := dec(in); err != nil {
 		return nil, err
@@ -156,7 +156,7 @@ func _BlobService_Delete_Handler(srv interface{}, ctx context.Context, dec func(
 		Server:     srv,
 		FullMethod: "/contentservice.BlobService/Delete",
 	}
-	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+	handler := func(ctx context.Context, req any) (any, error) {
 		return srv.(BlobServiceServer).Delete(ctx, req.(*DeleteRequest))
 	}
 	return interceptor(ctx, in, info, handler)

--- a/components/content-service-api/go/content.pb.go
+++ b/components/content-service-api/go/content.pb.go
@@ -146,7 +146,7 @@ func file_content_proto_rawDescGZIP() []byte {
 }
 
 var file_content_proto_msgTypes = make([]protoimpl.MessageInfo, 2)
-var file_content_proto_goTypes = []interface{}{
+var file_content_proto_goTypes = []any{
 	(*DeleteUserContentRequest)(nil),  // 0: contentservice.DeleteUserContentRequest
 	(*DeleteUserContentResponse)(nil), // 1: contentservice.DeleteUserContentResponse
 }
@@ -166,7 +166,7 @@ func file_content_proto_init() {
 		return
 	}
 	if !protoimpl.UnsafeEnabled {
-		file_content_proto_msgTypes[0].Exporter = func(v interface{}, i int) interface{} {
+		file_content_proto_msgTypes[0].Exporter = func(v any, i int) any {
 			switch v := v.(*DeleteUserContentRequest); i {
 			case 0:
 				return &v.state
@@ -178,7 +178,7 @@ func file_content_proto_init() {
 				return nil
 			}
 		}
-		file_content_proto_msgTypes[1].Exporter = func(v interface{}, i int) interface{} {
+		file_content_proto_msgTypes[1].Exporter = func(v any, i int) any {
 			switch v := v.(*DeleteUserContentResponse); i {
 			case 0:
 				return &v.state

--- a/components/content-service-api/go/content_grpc.pb.go
+++ b/components/content-service-api/go/content_grpc.pb.go
@@ -76,7 +76,7 @@ func RegisterContentServiceServer(s grpc.ServiceRegistrar, srv ContentServiceSer
 	s.RegisterService(&ContentService_ServiceDesc, srv)
 }
 
-func _ContentService_DeleteUserContent_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+func _ContentService_DeleteUserContent_Handler(srv any, ctx context.Context, dec func(any) error, interceptor grpc.UnaryServerInterceptor) (any, error) {
 	in := new(DeleteUserContentRequest)
 	if err := dec(in); err != nil {
 		return nil, err
@@ -88,7 +88,7 @@ func _ContentService_DeleteUserContent_Handler(srv interface{}, ctx context.Cont
 		Server:     srv,
 		FullMethod: "/contentservice.ContentService/DeleteUserContent",
 	}
-	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+	handler := func(ctx context.Context, req any) (any, error) {
 		return srv.(ContentServiceServer).DeleteUserContent(ctx, req.(*DeleteUserContentRequest))
 	}
 	return interceptor(ctx, in, info, handler)

--- a/components/content-service-api/go/headless-log.pb.go
+++ b/components/content-service-api/go/headless-log.pb.go
@@ -311,7 +311,7 @@ func file_headless_log_proto_rawDescGZIP() []byte {
 }
 
 var file_headless_log_proto_msgTypes = make([]protoimpl.MessageInfo, 4)
-var file_headless_log_proto_goTypes = []interface{}{
+var file_headless_log_proto_goTypes = []any{
 	(*LogDownloadURLRequest)(nil),  // 0: contentservice.LogDownloadURLRequest
 	(*LogDownloadURLResponse)(nil), // 1: contentservice.LogDownloadURLResponse
 	(*ListLogsRequest)(nil),        // 2: contentservice.ListLogsRequest
@@ -335,7 +335,7 @@ func file_headless_log_proto_init() {
 		return
 	}
 	if !protoimpl.UnsafeEnabled {
-		file_headless_log_proto_msgTypes[0].Exporter = func(v interface{}, i int) interface{} {
+		file_headless_log_proto_msgTypes[0].Exporter = func(v any, i int) any {
 			switch v := v.(*LogDownloadURLRequest); i {
 			case 0:
 				return &v.state
@@ -347,7 +347,7 @@ func file_headless_log_proto_init() {
 				return nil
 			}
 		}
-		file_headless_log_proto_msgTypes[1].Exporter = func(v interface{}, i int) interface{} {
+		file_headless_log_proto_msgTypes[1].Exporter = func(v any, i int) any {
 			switch v := v.(*LogDownloadURLResponse); i {
 			case 0:
 				return &v.state
@@ -359,7 +359,7 @@ func file_headless_log_proto_init() {
 				return nil
 			}
 		}
-		file_headless_log_proto_msgTypes[2].Exporter = func(v interface{}, i int) interface{} {
+		file_headless_log_proto_msgTypes[2].Exporter = func(v any, i int) any {
 			switch v := v.(*ListLogsRequest); i {
 			case 0:
 				return &v.state
@@ -371,7 +371,7 @@ func file_headless_log_proto_init() {
 				return nil
 			}
 		}
-		file_headless_log_proto_msgTypes[3].Exporter = func(v interface{}, i int) interface{} {
+		file_headless_log_proto_msgTypes[3].Exporter = func(v any, i int) any {
 			switch v := v.(*ListLogsResponse); i {
 			case 0:
 				return &v.state

--- a/components/content-service-api/go/headless-log_grpc.pb.go
+++ b/components/content-service-api/go/headless-log_grpc.pb.go
@@ -92,7 +92,7 @@ func RegisterHeadlessLogServiceServer(s grpc.ServiceRegistrar, srv HeadlessLogSe
 	s.RegisterService(&HeadlessLogService_ServiceDesc, srv)
 }
 
-func _HeadlessLogService_LogDownloadURL_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+func _HeadlessLogService_LogDownloadURL_Handler(srv any, ctx context.Context, dec func(any) error, interceptor grpc.UnaryServerInterceptor) (any, error) {
 	in := new(LogDownloadURLRequest)
 	if err := dec(in); err != nil {
 		return nil, err
@@ -104,13 +104,13 @@ func _HeadlessLogService_LogDownloadURL_Handler(srv interface{}, ctx context.Con
 		Server:     srv,
 		FullMethod: "/contentservice.HeadlessLogService/LogDownloadURL",
 	}
-	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+	handler := func(ctx context.Context, req any) (any, error) {
 		return srv.(HeadlessLogServiceServer).LogDownloadURL(ctx, req.(*LogDownloadURLRequest))
 	}
 	return interceptor(ctx, in, info, handler)
 }
 
-func _HeadlessLogService_ListLogs_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+func _HeadlessLogService_ListLogs_Handler(srv any, ctx context.Context, dec func(any) error, interceptor grpc.UnaryServerInterceptor) (any, error) {
 	in := new(ListLogsRequest)
 	if err := dec(in); err != nil {
 		return nil, err
@@ -122,7 +122,7 @@ func _HeadlessLogService_ListLogs_Handler(srv interface{}, ctx context.Context, 
 		Server:     srv,
 		FullMethod: "/contentservice.HeadlessLogService/ListLogs",
 	}
-	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+	handler := func(ctx context.Context, req any) (any, error) {
 		return srv.(HeadlessLogServiceServer).ListLogs(ctx, req.(*ListLogsRequest))
 	}
 	return interceptor(ctx, in, info, handler)

--- a/components/content-service-api/go/ideplugin.pb.go
+++ b/components/content-service-api/go/ideplugin.pb.go
@@ -392,7 +392,7 @@ func file_ideplugin_proto_rawDescGZIP() []byte {
 }
 
 var file_ideplugin_proto_msgTypes = make([]protoimpl.MessageInfo, 6)
-var file_ideplugin_proto_goTypes = []interface{}{
+var file_ideplugin_proto_goTypes = []any{
 	(*PluginUploadURLRequest)(nil),    // 0: ideplugin.PluginUploadURLRequest
 	(*PluginUploadURLResponse)(nil),   // 1: ideplugin.PluginUploadURLResponse
 	(*PluginDownloadURLRequest)(nil),  // 2: ideplugin.PluginDownloadURLRequest
@@ -420,7 +420,7 @@ func file_ideplugin_proto_init() {
 		return
 	}
 	if !protoimpl.UnsafeEnabled {
-		file_ideplugin_proto_msgTypes[0].Exporter = func(v interface{}, i int) interface{} {
+		file_ideplugin_proto_msgTypes[0].Exporter = func(v any, i int) any {
 			switch v := v.(*PluginUploadURLRequest); i {
 			case 0:
 				return &v.state
@@ -432,7 +432,7 @@ func file_ideplugin_proto_init() {
 				return nil
 			}
 		}
-		file_ideplugin_proto_msgTypes[1].Exporter = func(v interface{}, i int) interface{} {
+		file_ideplugin_proto_msgTypes[1].Exporter = func(v any, i int) any {
 			switch v := v.(*PluginUploadURLResponse); i {
 			case 0:
 				return &v.state
@@ -444,7 +444,7 @@ func file_ideplugin_proto_init() {
 				return nil
 			}
 		}
-		file_ideplugin_proto_msgTypes[2].Exporter = func(v interface{}, i int) interface{} {
+		file_ideplugin_proto_msgTypes[2].Exporter = func(v any, i int) any {
 			switch v := v.(*PluginDownloadURLRequest); i {
 			case 0:
 				return &v.state
@@ -456,7 +456,7 @@ func file_ideplugin_proto_init() {
 				return nil
 			}
 		}
-		file_ideplugin_proto_msgTypes[3].Exporter = func(v interface{}, i int) interface{} {
+		file_ideplugin_proto_msgTypes[3].Exporter = func(v any, i int) any {
 			switch v := v.(*PluginDownloadURLResponse); i {
 			case 0:
 				return &v.state
@@ -468,7 +468,7 @@ func file_ideplugin_proto_init() {
 				return nil
 			}
 		}
-		file_ideplugin_proto_msgTypes[4].Exporter = func(v interface{}, i int) interface{} {
+		file_ideplugin_proto_msgTypes[4].Exporter = func(v any, i int) any {
 			switch v := v.(*PluginHashRequest); i {
 			case 0:
 				return &v.state
@@ -480,7 +480,7 @@ func file_ideplugin_proto_init() {
 				return nil
 			}
 		}
-		file_ideplugin_proto_msgTypes[5].Exporter = func(v interface{}, i int) interface{} {
+		file_ideplugin_proto_msgTypes[5].Exporter = func(v any, i int) any {
 			switch v := v.(*PluginHashResponse); i {
 			case 0:
 				return &v.state

--- a/components/content-service-api/go/ideplugin_grpc.pb.go
+++ b/components/content-service-api/go/ideplugin_grpc.pb.go
@@ -108,7 +108,7 @@ func RegisterIDEPluginServiceServer(s grpc.ServiceRegistrar, srv IDEPluginServic
 	s.RegisterService(&IDEPluginService_ServiceDesc, srv)
 }
 
-func _IDEPluginService_UploadURL_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+func _IDEPluginService_UploadURL_Handler(srv any, ctx context.Context, dec func(any) error, interceptor grpc.UnaryServerInterceptor) (any, error) {
 	in := new(PluginUploadURLRequest)
 	if err := dec(in); err != nil {
 		return nil, err
@@ -120,13 +120,13 @@ func _IDEPluginService_UploadURL_Handler(srv interface{}, ctx context.Context, d
 		Server:     srv,
 		FullMethod: "/ideplugin.IDEPluginService/UploadURL",
 	}
-	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+	handler := func(ctx context.Context, req any) (any, error) {
 		return srv.(IDEPluginServiceServer).UploadURL(ctx, req.(*PluginUploadURLRequest))
 	}
 	return interceptor(ctx, in, info, handler)
 }
 
-func _IDEPluginService_DownloadURL_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+func _IDEPluginService_DownloadURL_Handler(srv any, ctx context.Context, dec func(any) error, interceptor grpc.UnaryServerInterceptor) (any, error) {
 	in := new(PluginDownloadURLRequest)
 	if err := dec(in); err != nil {
 		return nil, err
@@ -138,13 +138,13 @@ func _IDEPluginService_DownloadURL_Handler(srv interface{}, ctx context.Context,
 		Server:     srv,
 		FullMethod: "/ideplugin.IDEPluginService/DownloadURL",
 	}
-	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+	handler := func(ctx context.Context, req any) (any, error) {
 		return srv.(IDEPluginServiceServer).DownloadURL(ctx, req.(*PluginDownloadURLRequest))
 	}
 	return interceptor(ctx, in, info, handler)
 }
 
-func _IDEPluginService_PluginHash_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+func _IDEPluginService_PluginHash_Handler(srv any, ctx context.Context, dec func(any) error, interceptor grpc.UnaryServerInterceptor) (any, error) {
 	in := new(PluginHashRequest)
 	if err := dec(in); err != nil {
 		return nil, err
@@ -156,7 +156,7 @@ func _IDEPluginService_PluginHash_Handler(srv interface{}, ctx context.Context, 
 		Server:     srv,
 		FullMethod: "/ideplugin.IDEPluginService/PluginHash",
 	}
-	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+	handler := func(ctx context.Context, req any) (any, error) {
 		return srv.(IDEPluginServiceServer).PluginHash(ctx, req.(*PluginHashRequest))
 	}
 	return interceptor(ctx, in, info, handler)

--- a/components/content-service-api/go/initializer.pb.go
+++ b/components/content-service-api/go/initializer.pb.go
@@ -1130,7 +1130,7 @@ func file_initializer_proto_rawDescGZIP() []byte {
 
 var file_initializer_proto_enumTypes = make([]protoimpl.EnumInfo, 2)
 var file_initializer_proto_msgTypes = make([]protoimpl.MessageInfo, 12)
-var file_initializer_proto_goTypes = []interface{}{
+var file_initializer_proto_goTypes = []any{
 	(CloneTargetMode)(0),                     // 0: contentservice.CloneTargetMode
 	(GitAuthMethod)(0),                       // 1: contentservice.GitAuthMethod
 	(*WorkspaceInitializer)(nil),             // 2: contentservice.WorkspaceInitializer
@@ -1175,7 +1175,7 @@ func file_initializer_proto_init() {
 		return
 	}
 	if !protoimpl.UnsafeEnabled {
-		file_initializer_proto_msgTypes[0].Exporter = func(v interface{}, i int) interface{} {
+		file_initializer_proto_msgTypes[0].Exporter = func(v any, i int) any {
 			switch v := v.(*WorkspaceInitializer); i {
 			case 0:
 				return &v.state
@@ -1187,7 +1187,7 @@ func file_initializer_proto_init() {
 				return nil
 			}
 		}
-		file_initializer_proto_msgTypes[1].Exporter = func(v interface{}, i int) interface{} {
+		file_initializer_proto_msgTypes[1].Exporter = func(v any, i int) any {
 			switch v := v.(*CompositeInitializer); i {
 			case 0:
 				return &v.state
@@ -1199,7 +1199,7 @@ func file_initializer_proto_init() {
 				return nil
 			}
 		}
-		file_initializer_proto_msgTypes[2].Exporter = func(v interface{}, i int) interface{} {
+		file_initializer_proto_msgTypes[2].Exporter = func(v any, i int) any {
 			switch v := v.(*FileDownloadInitializer); i {
 			case 0:
 				return &v.state
@@ -1211,7 +1211,7 @@ func file_initializer_proto_init() {
 				return nil
 			}
 		}
-		file_initializer_proto_msgTypes[3].Exporter = func(v interface{}, i int) interface{} {
+		file_initializer_proto_msgTypes[3].Exporter = func(v any, i int) any {
 			switch v := v.(*EmptyInitializer); i {
 			case 0:
 				return &v.state
@@ -1223,7 +1223,7 @@ func file_initializer_proto_init() {
 				return nil
 			}
 		}
-		file_initializer_proto_msgTypes[4].Exporter = func(v interface{}, i int) interface{} {
+		file_initializer_proto_msgTypes[4].Exporter = func(v any, i int) any {
 			switch v := v.(*GitInitializer); i {
 			case 0:
 				return &v.state
@@ -1235,7 +1235,7 @@ func file_initializer_proto_init() {
 				return nil
 			}
 		}
-		file_initializer_proto_msgTypes[5].Exporter = func(v interface{}, i int) interface{} {
+		file_initializer_proto_msgTypes[5].Exporter = func(v any, i int) any {
 			switch v := v.(*GitConfig); i {
 			case 0:
 				return &v.state
@@ -1247,7 +1247,7 @@ func file_initializer_proto_init() {
 				return nil
 			}
 		}
-		file_initializer_proto_msgTypes[6].Exporter = func(v interface{}, i int) interface{} {
+		file_initializer_proto_msgTypes[6].Exporter = func(v any, i int) any {
 			switch v := v.(*SnapshotInitializer); i {
 			case 0:
 				return &v.state
@@ -1259,7 +1259,7 @@ func file_initializer_proto_init() {
 				return nil
 			}
 		}
-		file_initializer_proto_msgTypes[7].Exporter = func(v interface{}, i int) interface{} {
+		file_initializer_proto_msgTypes[7].Exporter = func(v any, i int) any {
 			switch v := v.(*PrebuildInitializer); i {
 			case 0:
 				return &v.state
@@ -1271,7 +1271,7 @@ func file_initializer_proto_init() {
 				return nil
 			}
 		}
-		file_initializer_proto_msgTypes[8].Exporter = func(v interface{}, i int) interface{} {
+		file_initializer_proto_msgTypes[8].Exporter = func(v any, i int) any {
 			switch v := v.(*FromBackupInitializer); i {
 			case 0:
 				return &v.state
@@ -1283,7 +1283,7 @@ func file_initializer_proto_init() {
 				return nil
 			}
 		}
-		file_initializer_proto_msgTypes[9].Exporter = func(v interface{}, i int) interface{} {
+		file_initializer_proto_msgTypes[9].Exporter = func(v any, i int) any {
 			switch v := v.(*GitStatus); i {
 			case 0:
 				return &v.state
@@ -1295,7 +1295,7 @@ func file_initializer_proto_init() {
 				return nil
 			}
 		}
-		file_initializer_proto_msgTypes[10].Exporter = func(v interface{}, i int) interface{} {
+		file_initializer_proto_msgTypes[10].Exporter = func(v any, i int) any {
 			switch v := v.(*FileDownloadInitializer_FileInfo); i {
 			case 0:
 				return &v.state
@@ -1308,7 +1308,7 @@ func file_initializer_proto_init() {
 			}
 		}
 	}
-	file_initializer_proto_msgTypes[0].OneofWrappers = []interface{}{
+	file_initializer_proto_msgTypes[0].OneofWrappers = []any{
 		(*WorkspaceInitializer_Empty)(nil),
 		(*WorkspaceInitializer_Git)(nil),
 		(*WorkspaceInitializer_Snapshot)(nil),

--- a/components/content-service-api/go/initializer_test.go
+++ b/components/content-service-api/go/initializer_test.go
@@ -184,7 +184,7 @@ func TestExtractInjectSecretsFromInitializer(t *testing.T) {
 				t.Errorf("unexpected GatherSecretsFromInitializer (-want +got):\n%s", diff)
 			}
 
-			ignoreUnexported := []interface{}{
+			ignoreUnexported := []any{
 				api.WorkspaceInitializer{},
 				api.WorkspaceInitializer_Git{},
 				api.GitInitializer{},

--- a/components/content-service-api/go/usage.pb.go
+++ b/components/content-service-api/go/usage.pb.go
@@ -264,7 +264,7 @@ func file_usage_proto_rawDescGZIP() []byte {
 }
 
 var file_usage_proto_msgTypes = make([]protoimpl.MessageInfo, 4)
-var file_usage_proto_goTypes = []interface{}{
+var file_usage_proto_goTypes = []any{
 	(*UsageReportUploadURLRequest)(nil),    // 0: contentservice.UsageReportUploadURLRequest
 	(*UsageReportUploadURLResponse)(nil),   // 1: contentservice.UsageReportUploadURLResponse
 	(*UsageReportDownloadURLRequest)(nil),  // 2: contentservice.UsageReportDownloadURLRequest
@@ -288,7 +288,7 @@ func file_usage_proto_init() {
 		return
 	}
 	if !protoimpl.UnsafeEnabled {
-		file_usage_proto_msgTypes[0].Exporter = func(v interface{}, i int) interface{} {
+		file_usage_proto_msgTypes[0].Exporter = func(v any, i int) any {
 			switch v := v.(*UsageReportUploadURLRequest); i {
 			case 0:
 				return &v.state
@@ -300,7 +300,7 @@ func file_usage_proto_init() {
 				return nil
 			}
 		}
-		file_usage_proto_msgTypes[1].Exporter = func(v interface{}, i int) interface{} {
+		file_usage_proto_msgTypes[1].Exporter = func(v any, i int) any {
 			switch v := v.(*UsageReportUploadURLResponse); i {
 			case 0:
 				return &v.state
@@ -312,7 +312,7 @@ func file_usage_proto_init() {
 				return nil
 			}
 		}
-		file_usage_proto_msgTypes[2].Exporter = func(v interface{}, i int) interface{} {
+		file_usage_proto_msgTypes[2].Exporter = func(v any, i int) any {
 			switch v := v.(*UsageReportDownloadURLRequest); i {
 			case 0:
 				return &v.state
@@ -324,7 +324,7 @@ func file_usage_proto_init() {
 				return nil
 			}
 		}
-		file_usage_proto_msgTypes[3].Exporter = func(v interface{}, i int) interface{} {
+		file_usage_proto_msgTypes[3].Exporter = func(v any, i int) any {
 			switch v := v.(*UsageReportDownloadURLResponse); i {
 			case 0:
 				return &v.state

--- a/components/content-service-api/go/usage_grpc.pb.go
+++ b/components/content-service-api/go/usage_grpc.pb.go
@@ -92,7 +92,7 @@ func RegisterUsageReportServiceServer(s grpc.ServiceRegistrar, srv UsageReportSe
 	s.RegisterService(&UsageReportService_ServiceDesc, srv)
 }
 
-func _UsageReportService_UploadURL_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+func _UsageReportService_UploadURL_Handler(srv any, ctx context.Context, dec func(any) error, interceptor grpc.UnaryServerInterceptor) (any, error) {
 	in := new(UsageReportUploadURLRequest)
 	if err := dec(in); err != nil {
 		return nil, err
@@ -104,13 +104,13 @@ func _UsageReportService_UploadURL_Handler(srv interface{}, ctx context.Context,
 		Server:     srv,
 		FullMethod: "/contentservice.UsageReportService/UploadURL",
 	}
-	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+	handler := func(ctx context.Context, req any) (any, error) {
 		return srv.(UsageReportServiceServer).UploadURL(ctx, req.(*UsageReportUploadURLRequest))
 	}
 	return interceptor(ctx, in, info, handler)
 }
 
-func _UsageReportService_DownloadURL_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+func _UsageReportService_DownloadURL_Handler(srv any, ctx context.Context, dec func(any) error, interceptor grpc.UnaryServerInterceptor) (any, error) {
 	in := new(UsageReportDownloadURLRequest)
 	if err := dec(in); err != nil {
 		return nil, err
@@ -122,7 +122,7 @@ func _UsageReportService_DownloadURL_Handler(srv interface{}, ctx context.Contex
 		Server:     srv,
 		FullMethod: "/contentservice.UsageReportService/DownloadURL",
 	}
-	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+	handler := func(ctx context.Context, req any) (any, error) {
 		return srv.(UsageReportServiceServer).DownloadURL(ctx, req.(*UsageReportDownloadURLRequest))
 	}
 	return interceptor(ctx, in, info, handler)

--- a/components/content-service-api/go/workspace.pb.go
+++ b/components/content-service-api/go/workspace.pb.go
@@ -415,7 +415,7 @@ func file_workspace_proto_rawDescGZIP() []byte {
 }
 
 var file_workspace_proto_msgTypes = make([]protoimpl.MessageInfo, 6)
-var file_workspace_proto_goTypes = []interface{}{
+var file_workspace_proto_goTypes = []any{
 	(*WorkspaceDownloadURLRequest)(nil),     // 0: contentservice.WorkspaceDownloadURLRequest
 	(*WorkspaceDownloadURLResponse)(nil),    // 1: contentservice.WorkspaceDownloadURLResponse
 	(*DeleteWorkspaceRequest)(nil),          // 2: contentservice.DeleteWorkspaceRequest
@@ -443,7 +443,7 @@ func file_workspace_proto_init() {
 		return
 	}
 	if !protoimpl.UnsafeEnabled {
-		file_workspace_proto_msgTypes[0].Exporter = func(v interface{}, i int) interface{} {
+		file_workspace_proto_msgTypes[0].Exporter = func(v any, i int) any {
 			switch v := v.(*WorkspaceDownloadURLRequest); i {
 			case 0:
 				return &v.state
@@ -455,7 +455,7 @@ func file_workspace_proto_init() {
 				return nil
 			}
 		}
-		file_workspace_proto_msgTypes[1].Exporter = func(v interface{}, i int) interface{} {
+		file_workspace_proto_msgTypes[1].Exporter = func(v any, i int) any {
 			switch v := v.(*WorkspaceDownloadURLResponse); i {
 			case 0:
 				return &v.state
@@ -467,7 +467,7 @@ func file_workspace_proto_init() {
 				return nil
 			}
 		}
-		file_workspace_proto_msgTypes[2].Exporter = func(v interface{}, i int) interface{} {
+		file_workspace_proto_msgTypes[2].Exporter = func(v any, i int) any {
 			switch v := v.(*DeleteWorkspaceRequest); i {
 			case 0:
 				return &v.state
@@ -479,7 +479,7 @@ func file_workspace_proto_init() {
 				return nil
 			}
 		}
-		file_workspace_proto_msgTypes[3].Exporter = func(v interface{}, i int) interface{} {
+		file_workspace_proto_msgTypes[3].Exporter = func(v any, i int) any {
 			switch v := v.(*DeleteWorkspaceResponse); i {
 			case 0:
 				return &v.state
@@ -491,7 +491,7 @@ func file_workspace_proto_init() {
 				return nil
 			}
 		}
-		file_workspace_proto_msgTypes[4].Exporter = func(v interface{}, i int) interface{} {
+		file_workspace_proto_msgTypes[4].Exporter = func(v any, i int) any {
 			switch v := v.(*WorkspaceSnapshotExistsRequest); i {
 			case 0:
 				return &v.state
@@ -503,7 +503,7 @@ func file_workspace_proto_init() {
 				return nil
 			}
 		}
-		file_workspace_proto_msgTypes[5].Exporter = func(v interface{}, i int) interface{} {
+		file_workspace_proto_msgTypes[5].Exporter = func(v any, i int) any {
 			switch v := v.(*WorkspaceSnapshotExistsResponse); i {
 			case 0:
 				return &v.state

--- a/components/content-service-api/go/workspace_grpc.pb.go
+++ b/components/content-service-api/go/workspace_grpc.pb.go
@@ -108,7 +108,7 @@ func RegisterWorkspaceServiceServer(s grpc.ServiceRegistrar, srv WorkspaceServic
 	s.RegisterService(&WorkspaceService_ServiceDesc, srv)
 }
 
-func _WorkspaceService_WorkspaceDownloadURL_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+func _WorkspaceService_WorkspaceDownloadURL_Handler(srv any, ctx context.Context, dec func(any) error, interceptor grpc.UnaryServerInterceptor) (any, error) {
 	in := new(WorkspaceDownloadURLRequest)
 	if err := dec(in); err != nil {
 		return nil, err
@@ -120,13 +120,13 @@ func _WorkspaceService_WorkspaceDownloadURL_Handler(srv interface{}, ctx context
 		Server:     srv,
 		FullMethod: "/contentservice.WorkspaceService/WorkspaceDownloadURL",
 	}
-	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+	handler := func(ctx context.Context, req any) (any, error) {
 		return srv.(WorkspaceServiceServer).WorkspaceDownloadURL(ctx, req.(*WorkspaceDownloadURLRequest))
 	}
 	return interceptor(ctx, in, info, handler)
 }
 
-func _WorkspaceService_DeleteWorkspace_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+func _WorkspaceService_DeleteWorkspace_Handler(srv any, ctx context.Context, dec func(any) error, interceptor grpc.UnaryServerInterceptor) (any, error) {
 	in := new(DeleteWorkspaceRequest)
 	if err := dec(in); err != nil {
 		return nil, err
@@ -138,13 +138,13 @@ func _WorkspaceService_DeleteWorkspace_Handler(srv interface{}, ctx context.Cont
 		Server:     srv,
 		FullMethod: "/contentservice.WorkspaceService/DeleteWorkspace",
 	}
-	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+	handler := func(ctx context.Context, req any) (any, error) {
 		return srv.(WorkspaceServiceServer).DeleteWorkspace(ctx, req.(*DeleteWorkspaceRequest))
 	}
 	return interceptor(ctx, in, info, handler)
 }
 
-func _WorkspaceService_WorkspaceSnapshotExists_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+func _WorkspaceService_WorkspaceSnapshotExists_Handler(srv any, ctx context.Context, dec func(any) error, interceptor grpc.UnaryServerInterceptor) (any, error) {
 	in := new(WorkspaceSnapshotExistsRequest)
 	if err := dec(in); err != nil {
 		return nil, err
@@ -156,7 +156,7 @@ func _WorkspaceService_WorkspaceSnapshotExists_Handler(srv interface{}, ctx cont
 		Server:     srv,
 		FullMethod: "/contentservice.WorkspaceService/WorkspaceSnapshotExists",
 	}
-	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+	handler := func(ctx context.Context, req any) (any, error) {
 		return srv.(WorkspaceServiceServer).WorkspaceSnapshotExists(ctx, req.(*WorkspaceSnapshotExistsRequest))
 	}
 	return interceptor(ctx, in, info, handler)

--- a/components/content-service/pkg/storage/gcloud.go
+++ b/components/content-service/pkg/storage/gcloud.go
@@ -36,7 +36,7 @@ import (
 
 var _ DirectAccess = &DirectGCPStorage{}
 
-var validateExistsInFilesystem = validation.By(func(o interface{}) error {
+var validateExistsInFilesystem = validation.By(func(o any) error {
 	s, ok := o.(string)
 	if !ok {
 		return xerrors.Errorf("field should be string")

--- a/components/content-service/pkg/storage/mock/mock.go
+++ b/components/content-service/pkg/storage/mock/mock.go
@@ -49,7 +49,7 @@ func (m *MockPresignedAccess) BackupObject(arg0, arg1, arg2 string) string {
 }
 
 // BackupObject indicates an expected call of BackupObject.
-func (mr *MockPresignedAccessMockRecorder) BackupObject(arg0, arg1, arg2 interface{}) *gomock.Call {
+func (mr *MockPresignedAccessMockRecorder) BackupObject(arg0, arg1, arg2 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BackupObject", reflect.TypeOf((*MockPresignedAccess)(nil).BackupObject), arg0, arg1, arg2)
 }
@@ -64,7 +64,7 @@ func (m *MockPresignedAccess) BlobObject(arg0 string) (string, error) {
 }
 
 // BlobObject indicates an expected call of BlobObject.
-func (mr *MockPresignedAccessMockRecorder) BlobObject(arg0 interface{}) *gomock.Call {
+func (mr *MockPresignedAccessMockRecorder) BlobObject(arg0 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BlobObject", reflect.TypeOf((*MockPresignedAccess)(nil).BlobObject), arg0)
 }
@@ -78,7 +78,7 @@ func (m *MockPresignedAccess) Bucket(arg0 string) string {
 }
 
 // Bucket indicates an expected call of Bucket.
-func (mr *MockPresignedAccessMockRecorder) Bucket(arg0 interface{}) *gomock.Call {
+func (mr *MockPresignedAccessMockRecorder) Bucket(arg0 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Bucket", reflect.TypeOf((*MockPresignedAccess)(nil).Bucket), arg0)
 }
@@ -92,7 +92,7 @@ func (m *MockPresignedAccess) DeleteBucket(arg0 context.Context, arg1 string) er
 }
 
 // DeleteBucket indicates an expected call of DeleteBucket.
-func (mr *MockPresignedAccessMockRecorder) DeleteBucket(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockPresignedAccessMockRecorder) DeleteBucket(arg0, arg1 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteBucket", reflect.TypeOf((*MockPresignedAccess)(nil).DeleteBucket), arg0, arg1)
 }
@@ -106,7 +106,7 @@ func (m *MockPresignedAccess) DeleteObject(arg0 context.Context, arg1 string, ar
 }
 
 // DeleteObject indicates an expected call of DeleteObject.
-func (mr *MockPresignedAccessMockRecorder) DeleteObject(arg0, arg1, arg2 interface{}) *gomock.Call {
+func (mr *MockPresignedAccessMockRecorder) DeleteObject(arg0, arg1, arg2 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteObject", reflect.TypeOf((*MockPresignedAccess)(nil).DeleteObject), arg0, arg1, arg2)
 }
@@ -121,7 +121,7 @@ func (m *MockPresignedAccess) DiskUsage(arg0 context.Context, arg1, arg2 string)
 }
 
 // DiskUsage indicates an expected call of DiskUsage.
-func (mr *MockPresignedAccessMockRecorder) DiskUsage(arg0, arg1, arg2 interface{}) *gomock.Call {
+func (mr *MockPresignedAccessMockRecorder) DiskUsage(arg0, arg1, arg2 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DiskUsage", reflect.TypeOf((*MockPresignedAccess)(nil).DiskUsage), arg0, arg1, arg2)
 }
@@ -135,7 +135,7 @@ func (m *MockPresignedAccess) EnsureExists(arg0 context.Context, arg1 string) er
 }
 
 // EnsureExists indicates an expected call of EnsureExists.
-func (mr *MockPresignedAccessMockRecorder) EnsureExists(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockPresignedAccessMockRecorder) EnsureExists(arg0, arg1 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EnsureExists", reflect.TypeOf((*MockPresignedAccess)(nil).EnsureExists), arg0, arg1)
 }
@@ -149,7 +149,7 @@ func (m *MockPresignedAccess) InstanceObject(arg0, arg1, arg2, arg3 string) stri
 }
 
 // InstanceObject indicates an expected call of InstanceObject.
-func (mr *MockPresignedAccessMockRecorder) InstanceObject(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
+func (mr *MockPresignedAccessMockRecorder) InstanceObject(arg0, arg1, arg2, arg3 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InstanceObject", reflect.TypeOf((*MockPresignedAccess)(nil).InstanceObject), arg0, arg1, arg2, arg3)
 }
@@ -164,7 +164,7 @@ func (m *MockPresignedAccess) ObjectExists(arg0 context.Context, arg1, arg2 stri
 }
 
 // ObjectExists indicates an expected call of ObjectExists.
-func (mr *MockPresignedAccessMockRecorder) ObjectExists(arg0, arg1, arg2 interface{}) *gomock.Call {
+func (mr *MockPresignedAccessMockRecorder) ObjectExists(arg0, arg1, arg2 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ObjectExists", reflect.TypeOf((*MockPresignedAccess)(nil).ObjectExists), arg0, arg1, arg2)
 }
@@ -179,7 +179,7 @@ func (m *MockPresignedAccess) ObjectHash(arg0 context.Context, arg1, arg2 string
 }
 
 // ObjectHash indicates an expected call of ObjectHash.
-func (mr *MockPresignedAccessMockRecorder) ObjectHash(arg0, arg1, arg2 interface{}) *gomock.Call {
+func (mr *MockPresignedAccessMockRecorder) ObjectHash(arg0, arg1, arg2 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ObjectHash", reflect.TypeOf((*MockPresignedAccess)(nil).ObjectHash), arg0, arg1, arg2)
 }
@@ -194,7 +194,7 @@ func (m *MockPresignedAccess) SignDownload(arg0 context.Context, arg1, arg2 stri
 }
 
 // SignDownload indicates an expected call of SignDownload.
-func (mr *MockPresignedAccessMockRecorder) SignDownload(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
+func (mr *MockPresignedAccessMockRecorder) SignDownload(arg0, arg1, arg2, arg3 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SignDownload", reflect.TypeOf((*MockPresignedAccess)(nil).SignDownload), arg0, arg1, arg2, arg3)
 }
@@ -209,7 +209,7 @@ func (m *MockPresignedAccess) SignUpload(arg0 context.Context, arg1, arg2 string
 }
 
 // SignUpload indicates an expected call of SignUpload.
-func (mr *MockPresignedAccessMockRecorder) SignUpload(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
+func (mr *MockPresignedAccessMockRecorder) SignUpload(arg0, arg1, arg2, arg3 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SignUpload", reflect.TypeOf((*MockPresignedAccess)(nil).SignUpload), arg0, arg1, arg2, arg3)
 }
@@ -246,7 +246,7 @@ func (m *MockDirectAccess) BackupObject(arg0 string) string {
 }
 
 // BackupObject indicates an expected call of BackupObject.
-func (mr *MockDirectAccessMockRecorder) BackupObject(arg0 interface{}) *gomock.Call {
+func (mr *MockDirectAccessMockRecorder) BackupObject(arg0 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BackupObject", reflect.TypeOf((*MockDirectAccess)(nil).BackupObject), arg0)
 }
@@ -260,7 +260,7 @@ func (m *MockDirectAccess) Bucket(arg0 string) string {
 }
 
 // Bucket indicates an expected call of Bucket.
-func (mr *MockDirectAccessMockRecorder) Bucket(arg0 interface{}) *gomock.Call {
+func (mr *MockDirectAccessMockRecorder) Bucket(arg0 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Bucket", reflect.TypeOf((*MockDirectAccess)(nil).Bucket), arg0)
 }
@@ -275,7 +275,7 @@ func (m *MockDirectAccess) Download(arg0 context.Context, arg1, arg2 string, arg
 }
 
 // Download indicates an expected call of Download.
-func (mr *MockDirectAccessMockRecorder) Download(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
+func (mr *MockDirectAccessMockRecorder) Download(arg0, arg1, arg2, arg3 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Download", reflect.TypeOf((*MockDirectAccess)(nil).Download), arg0, arg1, arg2, arg3)
 }
@@ -290,7 +290,7 @@ func (m *MockDirectAccess) DownloadSnapshot(arg0 context.Context, arg1, arg2 str
 }
 
 // DownloadSnapshot indicates an expected call of DownloadSnapshot.
-func (mr *MockDirectAccessMockRecorder) DownloadSnapshot(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
+func (mr *MockDirectAccessMockRecorder) DownloadSnapshot(arg0, arg1, arg2, arg3 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DownloadSnapshot", reflect.TypeOf((*MockDirectAccess)(nil).DownloadSnapshot), arg0, arg1, arg2, arg3)
 }
@@ -304,7 +304,7 @@ func (m *MockDirectAccess) EnsureExists(arg0 context.Context) error {
 }
 
 // EnsureExists indicates an expected call of EnsureExists.
-func (mr *MockDirectAccessMockRecorder) EnsureExists(arg0 interface{}) *gomock.Call {
+func (mr *MockDirectAccessMockRecorder) EnsureExists(arg0 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EnsureExists", reflect.TypeOf((*MockDirectAccess)(nil).EnsureExists), arg0)
 }
@@ -318,7 +318,7 @@ func (m *MockDirectAccess) Init(arg0 context.Context, arg1, arg2, arg3 string) e
 }
 
 // Init indicates an expected call of Init.
-func (mr *MockDirectAccessMockRecorder) Init(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
+func (mr *MockDirectAccessMockRecorder) Init(arg0, arg1, arg2, arg3 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Init", reflect.TypeOf((*MockDirectAccess)(nil).Init), arg0, arg1, arg2, arg3)
 }
@@ -333,7 +333,7 @@ func (m *MockDirectAccess) ListObjects(arg0 context.Context, arg1 string) ([]str
 }
 
 // ListObjects indicates an expected call of ListObjects.
-func (mr *MockDirectAccessMockRecorder) ListObjects(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockDirectAccessMockRecorder) ListObjects(arg0, arg1 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListObjects", reflect.TypeOf((*MockDirectAccess)(nil).ListObjects), arg0, arg1)
 }
@@ -347,7 +347,7 @@ func (m *MockDirectAccess) Qualify(arg0 string) string {
 }
 
 // Qualify indicates an expected call of Qualify.
-func (mr *MockDirectAccessMockRecorder) Qualify(arg0 interface{}) *gomock.Call {
+func (mr *MockDirectAccessMockRecorder) Qualify(arg0 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Qualify", reflect.TypeOf((*MockDirectAccess)(nil).Qualify), arg0)
 }
@@ -355,7 +355,7 @@ func (mr *MockDirectAccessMockRecorder) Qualify(arg0 interface{}) *gomock.Call {
 // Upload mocks base method.
 func (m *MockDirectAccess) Upload(arg0 context.Context, arg1, arg2 string, arg3 ...storage.UploadOption) (string, string, error) {
 	m.ctrl.T.Helper()
-	varargs := []interface{}{arg0, arg1, arg2}
+	varargs := []any{arg0, arg1, arg2}
 	for _, a := range arg3 {
 		varargs = append(varargs, a)
 	}
@@ -367,16 +367,16 @@ func (m *MockDirectAccess) Upload(arg0 context.Context, arg1, arg2 string, arg3 
 }
 
 // Upload indicates an expected call of Upload.
-func (mr *MockDirectAccessMockRecorder) Upload(arg0, arg1, arg2 interface{}, arg3 ...interface{}) *gomock.Call {
+func (mr *MockDirectAccessMockRecorder) Upload(arg0, arg1, arg2 any, arg3 ...any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	varargs := append([]interface{}{arg0, arg1, arg2}, arg3...)
+	varargs := append([]any{arg0, arg1, arg2}, arg3...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Upload", reflect.TypeOf((*MockDirectAccess)(nil).Upload), varargs...)
 }
 
 // UploadInstance mocks base method.
 func (m *MockDirectAccess) UploadInstance(arg0 context.Context, arg1, arg2 string, arg3 ...storage.UploadOption) (string, string, error) {
 	m.ctrl.T.Helper()
-	varargs := []interface{}{arg0, arg1, arg2}
+	varargs := []any{arg0, arg1, arg2}
 	for _, a := range arg3 {
 		varargs = append(varargs, a)
 	}
@@ -388,8 +388,8 @@ func (m *MockDirectAccess) UploadInstance(arg0 context.Context, arg1, arg2 strin
 }
 
 // UploadInstance indicates an expected call of UploadInstance.
-func (mr *MockDirectAccessMockRecorder) UploadInstance(arg0, arg1, arg2 interface{}, arg3 ...interface{}) *gomock.Call {
+func (mr *MockDirectAccessMockRecorder) UploadInstance(arg0, arg1, arg2 any, arg3 ...any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	varargs := append([]interface{}{arg0, arg1, arg2}, arg3...)
+	varargs := append([]any{arg0, arg1, arg2}, arg3...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UploadInstance", reflect.TypeOf((*MockDirectAccess)(nil).UploadInstance), varargs...)
 }

--- a/components/gitpod-cli/pkg/gitpodlib/config.go
+++ b/components/gitpod-cli/pkg/gitpodlib/config.go
@@ -19,7 +19,7 @@ type gitpodTask struct {
 }
 
 type GitpodFile struct {
-	Image             interface{}  `yaml:"image,omitempty"`
+	Image             any          `yaml:"image,omitempty"`
 	Ports             []gitpodPort `yaml:"ports,omitempty"`
 	Tasks             []gitpodTask `yaml:"tasks,omitempty"`
 	CheckoutLocation  string       `yaml:"checkoutLocation,omitempty"`

--- a/components/gitpod-cli/pkg/theialib/mock.go
+++ b/components/gitpod-cli/pkg/theialib/mock.go
@@ -47,7 +47,7 @@ func (m *MockTheiaCLIService) GetGitToken(arg0 GetGitTokenRequest) (*GetGitToken
 }
 
 // GetGitToken indicates an expected call of GetGitToken
-func (mr *MockTheiaCLIServiceMockRecorder) GetGitToken(arg0 interface{}) *gomock.Call {
+func (mr *MockTheiaCLIServiceMockRecorder) GetGitToken(arg0 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetGitToken", reflect.TypeOf((*MockTheiaCLIService)(nil).GetGitToken), arg0)
 }
@@ -62,7 +62,7 @@ func (m *MockTheiaCLIService) OpenPreview(arg0 OpenPreviewRequest) (*OpenPreview
 }
 
 // OpenPreview indicates an expected call of OpenPreview
-func (mr *MockTheiaCLIServiceMockRecorder) OpenPreview(arg0 interface{}) *gomock.Call {
+func (mr *MockTheiaCLIServiceMockRecorder) OpenPreview(arg0 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "OpenPreview", reflect.TypeOf((*MockTheiaCLIService)(nil).OpenPreview), arg0)
 }
@@ -77,7 +77,7 @@ func (m *MockTheiaCLIService) OpenFile(arg0 OpenFileRequest) (*OpenFileResponse,
 }
 
 // OpenFile indicates an expected call of OpenFile
-func (mr *MockTheiaCLIServiceMockRecorder) OpenFile(arg0 interface{}) *gomock.Call {
+func (mr *MockTheiaCLIServiceMockRecorder) OpenFile(arg0 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "OpenFile", reflect.TypeOf((*MockTheiaCLIService)(nil).OpenFile), arg0)
 }
@@ -92,7 +92,7 @@ func (m *MockTheiaCLIService) IsFileOpen(arg0 IsFileOpenRequest) (*IsFileOpenRes
 }
 
 // IsFileOpen indicates an expected call of IsFileOpen
-func (mr *MockTheiaCLIServiceMockRecorder) IsFileOpen(arg0 interface{}) *gomock.Call {
+func (mr *MockTheiaCLIServiceMockRecorder) IsFileOpen(arg0 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsFileOpen", reflect.TypeOf((*MockTheiaCLIService)(nil).IsFileOpen), arg0)
 }
@@ -107,7 +107,7 @@ func (m *MockTheiaCLIService) GetEnvVars(arg0 GetEnvvarsRequest) (*GetEnvvarsRes
 }
 
 // GetEnvVars indicates an expected call of GetEnvVars
-func (mr *MockTheiaCLIServiceMockRecorder) GetEnvVars(arg0 interface{}) *gomock.Call {
+func (mr *MockTheiaCLIServiceMockRecorder) GetEnvVars(arg0 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetEnvVars", reflect.TypeOf((*MockTheiaCLIService)(nil).GetEnvVars), arg0)
 }
@@ -122,7 +122,7 @@ func (m *MockTheiaCLIService) SetEnvVar(arg0 SetEnvvarRequest) (*SetEnvvarRespon
 }
 
 // SetEnvVar indicates an expected call of SetEnvVar
-func (mr *MockTheiaCLIServiceMockRecorder) SetEnvVar(arg0 interface{}) *gomock.Call {
+func (mr *MockTheiaCLIServiceMockRecorder) SetEnvVar(arg0 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetEnvVar", reflect.TypeOf((*MockTheiaCLIService)(nil).SetEnvVar), arg0)
 }
@@ -137,7 +137,7 @@ func (m *MockTheiaCLIService) DeleteEnvVar(arg0 DeleteEnvvarRequest) (*DeleteEnv
 }
 
 // DeleteEnvVar indicates an expected call of DeleteEnvVar
-func (mr *MockTheiaCLIServiceMockRecorder) DeleteEnvVar(arg0 interface{}) *gomock.Call {
+func (mr *MockTheiaCLIServiceMockRecorder) DeleteEnvVar(arg0 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteEnvVar", reflect.TypeOf((*MockTheiaCLIService)(nil).DeleteEnvVar), arg0)
 }
@@ -152,7 +152,7 @@ func (m *MockTheiaCLIService) GetPortURL(arg0 GetPortURLRequest) (*GetPortURLRes
 }
 
 // GetPortURL indicates an expected call of GetPortURL
-func (mr *MockTheiaCLIServiceMockRecorder) GetPortURL(arg0 interface{}) *gomock.Call {
+func (mr *MockTheiaCLIServiceMockRecorder) GetPortURL(arg0 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetPortURL", reflect.TypeOf((*MockTheiaCLIService)(nil).GetPortURL), arg0)
 }

--- a/components/gitpod-cli/pkg/theialib/service.go
+++ b/components/gitpod-cli/pkg/theialib/service.go
@@ -66,8 +66,8 @@ func NewServiceFromEnv() (*HTTPTheiaService, error) {
 }
 
 type request struct {
-	Method string      `json:"method"`
-	Params interface{} `json:"params"`
+	Method string `json:"method"`
+	Params any    `json:"params"`
 }
 
 var (

--- a/components/gitpod-protocol/go/gitpod-config-types.go
+++ b/components/gitpod-protocol/go/gitpod-config-types.go
@@ -31,7 +31,7 @@ type Env struct {
 type Github struct {
 
 	// Set to true to enable workspace prebuilds, false to disable them. Defaults to true.
-	Prebuilds interface{} `yaml:"prebuilds,omitempty"`
+	Prebuilds any `yaml:"prebuilds,omitempty"`
 }
 
 // GitpodConfig
@@ -53,7 +53,7 @@ type GitpodConfig struct {
 	Github *Github `yaml:"github,omitempty"`
 
 	// The Docker image to run your workspace in.
-	Image interface{} `yaml:"image,omitempty"`
+	Image any `yaml:"image,omitempty"`
 
 	// Configure JetBrains integration
 	Jetbrains *Jetbrains `yaml:"jetbrains,omitempty"`
@@ -129,7 +129,7 @@ type PortsItems struct {
 	OnOpen string `yaml:"onOpen,omitempty"`
 
 	// The port number (e.g. 1337) or range (e.g. 3000-3999) to expose.
-	Port interface{} `yaml:"port"`
+	Port any `yaml:"port"`
 
 	// The protocol to be used. (deprecated)
 	Protocol string `yaml:"protocol,omitempty"`
@@ -152,10 +152,10 @@ type Prebuilds_object struct {
 	AddBadge bool `yaml:"addBadge,omitempty"`
 
 	// Add a commit check to pull requests. Set to 'fail-on-error' if you want broken prebuilds to block merging. Defaults to true.
-	AddCheck interface{} `yaml:"addCheck,omitempty"`
+	AddCheck any `yaml:"addCheck,omitempty"`
 
 	// Add a label to a PR when it's prebuilt. Set to true to use the default label (prebuilt-in-gitpod) or set to a string to use a different label name. This is a beta feature and may be unreliable. Defaults to false.
-	AddLabel interface{} `yaml:"addLabel,omitempty"`
+	AddLabel any `yaml:"addLabel,omitempty"`
 
 	// Enable prebuilds for all branches. Defaults to false.
 	Branches bool `yaml:"branches,omitempty"`

--- a/components/gitpod-protocol/go/gitpod-service.go
+++ b/components/gitpod-protocol/go/gitpod-service.go
@@ -321,7 +321,7 @@ func (gp *APIoverJSONRPC) InstanceUpdates(ctx context.Context, instanceID string
 	return chn, nil
 }
 
-func (gp *APIoverJSONRPC) handler(ctx context.Context, conn *jsonrpc2.Conn, req *jsonrpc2.Request) (result interface{}, err error) {
+func (gp *APIoverJSONRPC) handler(ctx context.Context, conn *jsonrpc2.Conn, req *jsonrpc2.Request) (result any, err error) {
 	if gp == nil {
 		err = errNotConnected
 		return
@@ -360,7 +360,7 @@ func (gp *APIoverJSONRPC) GetOwnerToken(ctx context.Context, workspaceID string)
 		err = errNotConnected
 		return
 	}
-	var _params []interface{}
+	var _params []any
 	_params = append(_params, workspaceID)
 
 	var _result string
@@ -378,10 +378,10 @@ func (gp *APIoverJSONRPC) AdminBlockUser(ctx context.Context, message *AdminBloc
 		err = errNotConnected
 		return
 	}
-	var _params []interface{}
+	var _params []any
 	_params = append(_params, message)
 
-	var _result interface{}
+	var _result any
 	err = gp.C.Call(ctx, "adminBlockUser", _params, &_result)
 	if err != nil {
 		return err
@@ -395,7 +395,7 @@ func (gp *APIoverJSONRPC) GetLoggedInUser(ctx context.Context) (res *User, err e
 		err = errNotConnected
 		return
 	}
-	var _params []interface{}
+	var _params []any
 
 	var result User
 	err = gp.C.Call(ctx, "getLoggedInUser", _params, &result)
@@ -413,7 +413,7 @@ func (gp *APIoverJSONRPC) UpdateLoggedInUser(ctx context.Context, user *User) (r
 		err = errNotConnected
 		return
 	}
-	var _params []interface{}
+	var _params []any
 
 	_params = append(_params, user)
 
@@ -433,7 +433,7 @@ func (gp *APIoverJSONRPC) GetAuthProviders(ctx context.Context) (res []*AuthProv
 		err = errNotConnected
 		return
 	}
-	var _params []interface{}
+	var _params []any
 
 	var result []*AuthProviderInfo
 	err = gp.C.Call(ctx, "getAuthProviders", _params, &result)
@@ -451,7 +451,7 @@ func (gp *APIoverJSONRPC) GetOwnAuthProviders(ctx context.Context) (res []*AuthP
 		err = errNotConnected
 		return
 	}
-	var _params []interface{}
+	var _params []any
 
 	var result []*AuthProviderEntry
 	err = gp.C.Call(ctx, "getOwnAuthProviders", _params, &result)
@@ -469,7 +469,7 @@ func (gp *APIoverJSONRPC) UpdateOwnAuthProvider(ctx context.Context, params *Upd
 		err = errNotConnected
 		return
 	}
-	var _params []interface{}
+	var _params []any
 
 	_params = append(_params, params)
 
@@ -487,7 +487,7 @@ func (gp *APIoverJSONRPC) DeleteOwnAuthProvider(ctx context.Context, params *Del
 		err = errNotConnected
 		return
 	}
-	var _params []interface{}
+	var _params []any
 
 	_params = append(_params, params)
 
@@ -505,7 +505,7 @@ func (gp *APIoverJSONRPC) GetConfiguration(ctx context.Context) (res *Configurat
 		err = errNotConnected
 		return
 	}
-	var _params []interface{}
+	var _params []any
 
 	var result Configuration
 	err = gp.C.Call(ctx, "getConfiguration", _params, &result)
@@ -523,7 +523,7 @@ func (gp *APIoverJSONRPC) GetGitpodTokenScopes(ctx context.Context, tokenHash st
 		err = errNotConnected
 		return
 	}
-	var _params []interface{}
+	var _params []any
 
 	_params = append(_params, tokenHash)
 
@@ -543,7 +543,7 @@ func (gp *APIoverJSONRPC) GetToken(ctx context.Context, query *GetTokenSearchOpt
 		err = errNotConnected
 		return
 	}
-	var _params []interface{}
+	var _params []any
 
 	_params = append(_params, query)
 
@@ -563,7 +563,7 @@ func (gp *APIoverJSONRPC) GetPortAuthenticationToken(ctx context.Context, worksp
 		err = errNotConnected
 		return
 	}
-	var _params []interface{}
+	var _params []any
 
 	_params = append(_params, workspaceID)
 
@@ -583,7 +583,7 @@ func (gp *APIoverJSONRPC) DeleteAccount(ctx context.Context) (err error) {
 		err = errNotConnected
 		return
 	}
-	var _params []interface{}
+	var _params []any
 
 	err = gp.C.Call(ctx, "deleteAccount", _params, nil)
 	if err != nil {
@@ -599,7 +599,7 @@ func (gp *APIoverJSONRPC) GetClientRegion(ctx context.Context) (res string, err 
 		err = errNotConnected
 		return
 	}
-	var _params []interface{}
+	var _params []any
 
 	var result string
 	err = gp.C.Call(ctx, "getClientRegion", _params, &result)
@@ -617,7 +617,7 @@ func (gp *APIoverJSONRPC) HasPermission(ctx context.Context, permission *Permiss
 		err = errNotConnected
 		return
 	}
-	var _params []interface{}
+	var _params []any
 
 	_params = append(_params, permission)
 
@@ -637,7 +637,7 @@ func (gp *APIoverJSONRPC) GetWorkspaces(ctx context.Context, options *GetWorkspa
 		err = errNotConnected
 		return
 	}
-	var _params []interface{}
+	var _params []any
 
 	_params = append(_params, options)
 
@@ -657,7 +657,7 @@ func (gp *APIoverJSONRPC) GetWorkspaceOwner(ctx context.Context, workspaceID str
 		err = errNotConnected
 		return
 	}
-	var _params []interface{}
+	var _params []any
 
 	_params = append(_params, workspaceID)
 
@@ -677,7 +677,7 @@ func (gp *APIoverJSONRPC) GetWorkspaceUsers(ctx context.Context, workspaceID str
 		err = errNotConnected
 		return
 	}
-	var _params []interface{}
+	var _params []any
 
 	_params = append(_params, workspaceID)
 
@@ -697,7 +697,7 @@ func (gp *APIoverJSONRPC) GetFeaturedRepositories(ctx context.Context) (res []*W
 		err = errNotConnected
 		return
 	}
-	var _params []interface{}
+	var _params []any
 
 	var result []*WhitelistedRepository
 	err = gp.C.Call(ctx, "getFeaturedRepositories", _params, &result)
@@ -715,7 +715,7 @@ func (gp *APIoverJSONRPC) GetWorkspace(ctx context.Context, id string) (res *Wor
 		err = errNotConnected
 		return
 	}
-	var _params []interface{}
+	var _params []any
 
 	_params = append(_params, id)
 
@@ -735,7 +735,7 @@ func (gp *APIoverJSONRPC) IsWorkspaceOwner(ctx context.Context, workspaceID stri
 		err = errNotConnected
 		return
 	}
-	var _params []interface{}
+	var _params []any
 
 	_params = append(_params, workspaceID)
 
@@ -755,7 +755,7 @@ func (gp *APIoverJSONRPC) CreateWorkspace(ctx context.Context, options *CreateWo
 		err = errNotConnected
 		return
 	}
-	var _params []interface{}
+	var _params []any
 
 	_params = append(_params, options)
 
@@ -775,7 +775,7 @@ func (gp *APIoverJSONRPC) StartWorkspace(ctx context.Context, id string, options
 		err = errNotConnected
 		return
 	}
-	var _params []interface{}
+	var _params []any
 
 	_params = append(_params, id)
 	_params = append(_params, options)
@@ -796,7 +796,7 @@ func (gp *APIoverJSONRPC) StopWorkspace(ctx context.Context, id string) (err err
 		err = errNotConnected
 		return
 	}
-	var _params []interface{}
+	var _params []any
 
 	_params = append(_params, id)
 
@@ -814,7 +814,7 @@ func (gp *APIoverJSONRPC) DeleteWorkspace(ctx context.Context, id string) (err e
 		err = errNotConnected
 		return
 	}
-	var _params []interface{}
+	var _params []any
 
 	_params = append(_params, id)
 
@@ -832,7 +832,7 @@ func (gp *APIoverJSONRPC) SetWorkspaceDescription(ctx context.Context, id string
 		err = errNotConnected
 		return
 	}
-	var _params []interface{}
+	var _params []any
 
 	_params = append(_params, id)
 	_params = append(_params, desc)
@@ -851,7 +851,7 @@ func (gp *APIoverJSONRPC) ControlAdmission(ctx context.Context, id string, level
 		err = errNotConnected
 		return
 	}
-	var _params []interface{}
+	var _params []any
 
 	_params = append(_params, id)
 	_params = append(_params, level)
@@ -870,7 +870,7 @@ func (gp *APIoverJSONRPC) WatchWorkspaceImageBuildLogs(ctx context.Context, work
 		err = errNotConnected
 		return
 	}
-	var _params []interface{}
+	var _params []any
 
 	_params = append(_params, workspaceID)
 
@@ -888,7 +888,7 @@ func (gp *APIoverJSONRPC) IsPrebuildDone(ctx context.Context, pwsid string) (res
 		err = errNotConnected
 		return
 	}
-	var _params []interface{}
+	var _params []any
 
 	_params = append(_params, pwsid)
 
@@ -908,7 +908,7 @@ func (gp *APIoverJSONRPC) SetWorkspaceTimeout(ctx context.Context, workspaceID s
 		err = errNotConnected
 		return
 	}
-	var _params []interface{}
+	var _params []any
 
 	_params = append(_params, workspaceID)
 	_params = append(_params, duration)
@@ -929,7 +929,7 @@ func (gp *APIoverJSONRPC) GetWorkspaceTimeout(ctx context.Context, workspaceID s
 		err = errNotConnected
 		return
 	}
-	var _params []interface{}
+	var _params []any
 
 	_params = append(_params, workspaceID)
 
@@ -949,7 +949,7 @@ func (gp *APIoverJSONRPC) SendHeartBeat(ctx context.Context, options *SendHeartB
 		err = errNotConnected
 		return
 	}
-	var _params []interface{}
+	var _params []any
 
 	_params = append(_params, options)
 
@@ -967,7 +967,7 @@ func (gp *APIoverJSONRPC) UpdateWorkspaceUserPin(ctx context.Context, id string,
 		err = errNotConnected
 		return
 	}
-	var _params []interface{}
+	var _params []any
 
 	_params = append(_params, id)
 	_params = append(_params, action)
@@ -986,7 +986,7 @@ func (gp *APIoverJSONRPC) GetOpenPorts(ctx context.Context, workspaceID string) 
 		err = errNotConnected
 		return
 	}
-	var _params []interface{}
+	var _params []any
 
 	_params = append(_params, workspaceID)
 
@@ -1006,7 +1006,7 @@ func (gp *APIoverJSONRPC) OpenPort(ctx context.Context, workspaceID string, port
 		err = errNotConnected
 		return
 	}
-	var _params []interface{}
+	var _params []any
 
 	_params = append(_params, workspaceID)
 	_params = append(_params, port)
@@ -1027,7 +1027,7 @@ func (gp *APIoverJSONRPC) ClosePort(ctx context.Context, workspaceID string, por
 		err = errNotConnected
 		return
 	}
-	var _params []interface{}
+	var _params []any
 
 	_params = append(_params, workspaceID)
 	_params = append(_params, port)
@@ -1046,7 +1046,7 @@ func (gp *APIoverJSONRPC) GetUserStorageResource(ctx context.Context, options *G
 		err = errNotConnected
 		return
 	}
-	var _params []interface{}
+	var _params []any
 
 	_params = append(_params, options)
 
@@ -1066,7 +1066,7 @@ func (gp *APIoverJSONRPC) UpdateUserStorageResource(ctx context.Context, options
 		err = errNotConnected
 		return
 	}
-	var _params []interface{}
+	var _params []any
 
 	_params = append(_params, options)
 
@@ -1084,7 +1084,7 @@ func (gp *APIoverJSONRPC) GetEnvVars(ctx context.Context) (res []*UserEnvVarValu
 		err = errNotConnected
 		return
 	}
-	var _params []interface{}
+	var _params []any
 
 	var result []*UserEnvVarValue
 	err = gp.C.Call(ctx, "getEnvVars", _params, &result)
@@ -1102,7 +1102,7 @@ func (gp *APIoverJSONRPC) SetEnvVar(ctx context.Context, variable *UserEnvVarVal
 		err = errNotConnected
 		return
 	}
-	var _params []interface{}
+	var _params []any
 
 	_params = append(_params, variable)
 
@@ -1120,7 +1120,7 @@ func (gp *APIoverJSONRPC) DeleteEnvVar(ctx context.Context, variable *UserEnvVar
 		err = errNotConnected
 		return
 	}
-	var _params []interface{}
+	var _params []any
 
 	_params = append(_params, variable)
 
@@ -1138,7 +1138,7 @@ func (gp *APIoverJSONRPC) HasSSHPublicKey(ctx context.Context) (res bool, err er
 		err = errNotConnected
 		return
 	}
-	var _params []interface{}
+	var _params []any
 	err = gp.C.Call(ctx, "hasSSHPublicKey", _params, &res)
 	return
 }
@@ -1149,7 +1149,7 @@ func (gp *APIoverJSONRPC) GetSSHPublicKeys(ctx context.Context) (res []*UserSSHP
 		err = errNotConnected
 		return
 	}
-	var _params []interface{}
+	var _params []any
 	err = gp.C.Call(ctx, "getSSHPublicKeys", _params, &res)
 	return
 }
@@ -1160,7 +1160,7 @@ func (gp *APIoverJSONRPC) AddSSHPublicKey(ctx context.Context, value *SSHPublicK
 		err = errNotConnected
 		return
 	}
-	_params := []interface{}{value}
+	_params := []any{value}
 	err = gp.C.Call(ctx, "addSSHPublicKey", _params, &res)
 	return
 }
@@ -1171,7 +1171,7 @@ func (gp *APIoverJSONRPC) DeleteSSHPublicKey(ctx context.Context, id string) (er
 		err = errNotConnected
 		return
 	}
-	_params := []interface{}{id}
+	_params := []any{id}
 	err = gp.C.Call(ctx, "deleteSSHPublicKey", _params, nil)
 	return
 }
@@ -1182,7 +1182,7 @@ func (gp *APIoverJSONRPC) GetContentBlobUploadURL(ctx context.Context, name stri
 		err = errNotConnected
 		return
 	}
-	var _params []interface{}
+	var _params []any
 
 	_params = append(_params, name)
 
@@ -1202,7 +1202,7 @@ func (gp *APIoverJSONRPC) GetContentBlobDownloadURL(ctx context.Context, name st
 		err = errNotConnected
 		return
 	}
-	var _params []interface{}
+	var _params []any
 
 	_params = append(_params, name)
 
@@ -1222,7 +1222,7 @@ func (gp *APIoverJSONRPC) GetGitpodTokens(ctx context.Context) (res []*APIToken,
 		err = errNotConnected
 		return
 	}
-	var _params []interface{}
+	var _params []any
 
 	var result []*APIToken
 	err = gp.C.Call(ctx, "getGitpodTokens", _params, &result)
@@ -1240,7 +1240,7 @@ func (gp *APIoverJSONRPC) GenerateNewGitpodToken(ctx context.Context, options *G
 		err = errNotConnected
 		return
 	}
-	var _params []interface{}
+	var _params []any
 
 	_params = append(_params, options)
 
@@ -1260,7 +1260,7 @@ func (gp *APIoverJSONRPC) DeleteGitpodToken(ctx context.Context, tokenHash strin
 		err = errNotConnected
 		return
 	}
-	var _params []interface{}
+	var _params []any
 
 	_params = append(_params, tokenHash)
 
@@ -1278,7 +1278,7 @@ func (gp *APIoverJSONRPC) SendFeedback(ctx context.Context, feedback string) (re
 		err = errNotConnected
 		return
 	}
-	var _params []interface{}
+	var _params []any
 
 	_params = append(_params, feedback)
 
@@ -1298,7 +1298,7 @@ func (gp *APIoverJSONRPC) RegisterGithubApp(ctx context.Context, installationID 
 		err = errNotConnected
 		return
 	}
-	var _params []interface{}
+	var _params []any
 
 	_params = append(_params, installationID)
 
@@ -1316,7 +1316,7 @@ func (gp *APIoverJSONRPC) TakeSnapshot(ctx context.Context, options *TakeSnapsho
 		err = errNotConnected
 		return
 	}
-	var _params []interface{}
+	var _params []any
 
 	_params = append(_params, options)
 
@@ -1336,7 +1336,7 @@ func (gp *APIoverJSONRPC) WaitForSnapshot(ctx context.Context, snapshotId string
 		err = errNotConnected
 		return
 	}
-	var _params []interface{}
+	var _params []any
 
 	_params = append(_params, snapshotId)
 
@@ -1351,7 +1351,7 @@ func (gp *APIoverJSONRPC) GetSnapshots(ctx context.Context, workspaceID string) 
 		err = errNotConnected
 		return
 	}
-	var _params []interface{}
+	var _params []any
 
 	_params = append(_params, workspaceID)
 
@@ -1371,7 +1371,7 @@ func (gp *APIoverJSONRPC) StoreLayout(ctx context.Context, workspaceID string, l
 		err = errNotConnected
 		return
 	}
-	var _params []interface{}
+	var _params []any
 
 	_params = append(_params, workspaceID)
 	_params = append(_params, layoutData)
@@ -1390,7 +1390,7 @@ func (gp *APIoverJSONRPC) GetLayout(ctx context.Context, workspaceID string) (re
 		err = errNotConnected
 		return
 	}
-	var _params []interface{}
+	var _params []any
 
 	_params = append(_params, workspaceID)
 
@@ -1410,7 +1410,7 @@ func (gp *APIoverJSONRPC) GuessGitTokenScopes(ctx context.Context, params *Guess
 		err = errNotConnected
 		return
 	}
-	var _params []interface{}
+	var _params []any
 
 	_params = append(_params, params)
 
@@ -1430,7 +1430,7 @@ func (gp *APIoverJSONRPC) TrackEvent(ctx context.Context, params *RemoteTrackMes
 		err = errNotConnected
 		return
 	}
-	var _params []interface{}
+	var _params []any
 
 	_params = append(_params, params)
 	err = gp.C.Call(ctx, "trackEvent", _params, nil)
@@ -1442,7 +1442,7 @@ func (gp *APIoverJSONRPC) GetSupportedWorkspaceClasses(ctx context.Context) (res
 		err = errNotConnected
 		return
 	}
-	_params := []interface{}{}
+	_params := []any{}
 	err = gp.C.Call(ctx, "getSupportedWorkspaceClasses", _params, &res)
 	return
 }
@@ -1644,10 +1644,10 @@ type Workspace struct {
 	// The source where to get the workspace base image from. This source is resolved
 	// during workspace creation. Once a base image has been built the information in here
 	// is superseded by baseImageNameResolved.
-	ImageSource interface{} `json:"imageSource,omitempty"`
-	OwnerID     string      `json:"ownerId,omitempty"`
-	Pinned      bool        `json:"pinned,omitempty"`
-	Shareable   bool        `json:"shareable,omitempty"`
+	ImageSource any    `json:"imageSource,omitempty"`
+	OwnerID     string `json:"ownerId,omitempty"`
+	Pinned      bool   `json:"pinned,omitempty"`
+	Shareable   bool   `json:"shareable,omitempty"`
 
 	// Mark as deleted (user-facing). The actual deletion of the workspace content is executed
 	// with a (configurable) delay
@@ -1670,7 +1670,7 @@ type WorkspaceConfig struct {
 	GitConfig    map[string]string `json:"gitConfig,omitempty"`
 	Github       *GithubAppConfig  `json:"github,omitempty"`
 	Ide          string            `json:"ide,omitempty"`
-	Image        interface{}       `json:"image,omitempty"`
+	Image        any               `json:"image,omitempty"`
 
 	// Where the config object originates from.
 	//
@@ -1796,14 +1796,14 @@ type GithubAppConfig struct {
 
 // GithubAppPrebuildConfig is the GithubAppPrebuildConfig message type
 type GithubAppPrebuildConfig struct {
-	AddBadge              bool        `json:"addBadge,omitempty"`
-	AddCheck              interface{} `json:"addCheck,omitempty"`
-	AddComment            bool        `json:"addComment,omitempty"`
-	AddLabel              interface{} `json:"addLabel,omitempty"`
-	Branches              bool        `json:"branches,omitempty"`
-	Master                bool        `json:"master,omitempty"`
-	PullRequests          bool        `json:"pullRequests,omitempty"`
-	PullRequestsFromForks bool        `json:"pullRequestsFromForks,omitempty"`
+	AddBadge              bool `json:"addBadge,omitempty"`
+	AddCheck              any  `json:"addCheck,omitempty"`
+	AddComment            bool `json:"addComment,omitempty"`
+	AddLabel              any  `json:"addLabel,omitempty"`
+	Branches              bool `json:"branches,omitempty"`
+	Master                bool `json:"master,omitempty"`
+	PullRequests          bool `json:"pullRequests,omitempty"`
+	PullRequestsFromForks bool `json:"pullRequestsFromForks,omitempty"`
 }
 
 // ImageConfigFile is the ImageConfigFile message type
@@ -1823,14 +1823,14 @@ type PortConfig struct {
 
 // TaskConfig is the TaskConfig message type
 type TaskConfig struct {
-	Before   string                 `json:"before,omitempty"`
-	Command  string                 `json:"command,omitempty"`
-	Env      map[string]interface{} `json:"env,omitempty"`
-	Init     string                 `json:"init,omitempty"`
-	Name     string                 `json:"name,omitempty"`
-	OpenIn   string                 `json:"openIn,omitempty"`
-	OpenMode string                 `json:"openMode,omitempty"`
-	Prebuild string                 `json:"prebuild,omitempty"`
+	Before   string         `json:"before,omitempty"`
+	Command  string         `json:"command,omitempty"`
+	Env      map[string]any `json:"env,omitempty"`
+	Init     string         `json:"init,omitempty"`
+	Name     string         `json:"name,omitempty"`
+	OpenIn   string         `json:"openIn,omitempty"`
+	OpenMode string         `json:"openMode,omitempty"`
+	Prebuild string         `json:"prebuild,omitempty"`
 }
 
 // VSCodeConfig is the VSCodeConfig message type
@@ -1916,7 +1916,7 @@ type PickOAuth2ConfigClientIDClientSecret struct {
 
 // UpdateOwnAuthProviderParams is the UpdateOwnAuthProviderParams message type
 type UpdateOwnAuthProviderParams struct {
-	Entry interface{} `json:"entry,omitempty"`
+	Entry any `json:"entry,omitempty"`
 }
 
 // CreateWorkspaceOptions is the CreateWorkspaceOptions message type
@@ -1961,8 +1961,8 @@ type SupportedWorkspaceClass struct {
 }
 
 type RemoteTrackMessage struct {
-	Event      string      `json:"event,omitempty"`
-	Properties interface{} `json:"properties,omitempty"`
+	Event      string `json:"event,omitempty"`
+	Properties any    `json:"properties,omitempty"`
 }
 
 // WorkspaceInstanceUser is the WorkspaceInstanceUser message type

--- a/components/gitpod-protocol/go/mock.go
+++ b/components/gitpod-protocol/go/mock.go
@@ -48,7 +48,7 @@ func (m *MockAPIInterface) AddSSHPublicKey(ctx context.Context, value *SSHPublic
 }
 
 // AddSSHPublicKey indicates an expected call of AddSSHPublicKey.
-func (mr *MockAPIInterfaceMockRecorder) AddSSHPublicKey(ctx, value interface{}) *gomock.Call {
+func (mr *MockAPIInterfaceMockRecorder) AddSSHPublicKey(ctx, value any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddSSHPublicKey", reflect.TypeOf((*MockAPIInterface)(nil).AddSSHPublicKey), ctx, value)
 }
@@ -62,7 +62,7 @@ func (m *MockAPIInterface) AdminBlockUser(ctx context.Context, req *AdminBlockUs
 }
 
 // AdminBlockUser indicates an expected call of AdminBlockUser.
-func (mr *MockAPIInterfaceMockRecorder) AdminBlockUser(ctx, req interface{}) *gomock.Call {
+func (mr *MockAPIInterfaceMockRecorder) AdminBlockUser(ctx, req any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AdminBlockUser", reflect.TypeOf((*MockAPIInterface)(nil).AdminBlockUser), ctx, req)
 }
@@ -76,7 +76,7 @@ func (m *MockAPIInterface) ClosePort(ctx context.Context, workspaceID string, po
 }
 
 // ClosePort indicates an expected call of ClosePort.
-func (mr *MockAPIInterfaceMockRecorder) ClosePort(ctx, workspaceID, port interface{}) *gomock.Call {
+func (mr *MockAPIInterfaceMockRecorder) ClosePort(ctx, workspaceID, port any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ClosePort", reflect.TypeOf((*MockAPIInterface)(nil).ClosePort), ctx, workspaceID, port)
 }
@@ -90,7 +90,7 @@ func (m *MockAPIInterface) ControlAdmission(ctx context.Context, id string, leve
 }
 
 // ControlAdmission indicates an expected call of ControlAdmission.
-func (mr *MockAPIInterfaceMockRecorder) ControlAdmission(ctx, id, level interface{}) *gomock.Call {
+func (mr *MockAPIInterfaceMockRecorder) ControlAdmission(ctx, id, level any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ControlAdmission", reflect.TypeOf((*MockAPIInterface)(nil).ControlAdmission), ctx, id, level)
 }
@@ -105,7 +105,7 @@ func (m *MockAPIInterface) CreateWorkspace(ctx context.Context, options *CreateW
 }
 
 // CreateWorkspace indicates an expected call of CreateWorkspace.
-func (mr *MockAPIInterfaceMockRecorder) CreateWorkspace(ctx, options interface{}) *gomock.Call {
+func (mr *MockAPIInterfaceMockRecorder) CreateWorkspace(ctx, options any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateWorkspace", reflect.TypeOf((*MockAPIInterface)(nil).CreateWorkspace), ctx, options)
 }
@@ -119,7 +119,7 @@ func (m *MockAPIInterface) DeleteAccount(ctx context.Context) error {
 }
 
 // DeleteAccount indicates an expected call of DeleteAccount.
-func (mr *MockAPIInterfaceMockRecorder) DeleteAccount(ctx interface{}) *gomock.Call {
+func (mr *MockAPIInterfaceMockRecorder) DeleteAccount(ctx any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteAccount", reflect.TypeOf((*MockAPIInterface)(nil).DeleteAccount), ctx)
 }
@@ -133,7 +133,7 @@ func (m *MockAPIInterface) DeleteEnvVar(ctx context.Context, variable *UserEnvVa
 }
 
 // DeleteEnvVar indicates an expected call of DeleteEnvVar.
-func (mr *MockAPIInterfaceMockRecorder) DeleteEnvVar(ctx, variable interface{}) *gomock.Call {
+func (mr *MockAPIInterfaceMockRecorder) DeleteEnvVar(ctx, variable any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteEnvVar", reflect.TypeOf((*MockAPIInterface)(nil).DeleteEnvVar), ctx, variable)
 }
@@ -147,7 +147,7 @@ func (m *MockAPIInterface) DeleteGitpodToken(ctx context.Context, tokenHash stri
 }
 
 // DeleteGitpodToken indicates an expected call of DeleteGitpodToken.
-func (mr *MockAPIInterfaceMockRecorder) DeleteGitpodToken(ctx, tokenHash interface{}) *gomock.Call {
+func (mr *MockAPIInterfaceMockRecorder) DeleteGitpodToken(ctx, tokenHash any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteGitpodToken", reflect.TypeOf((*MockAPIInterface)(nil).DeleteGitpodToken), ctx, tokenHash)
 }
@@ -161,7 +161,7 @@ func (m *MockAPIInterface) DeleteOwnAuthProvider(ctx context.Context, params *De
 }
 
 // DeleteOwnAuthProvider indicates an expected call of DeleteOwnAuthProvider.
-func (mr *MockAPIInterfaceMockRecorder) DeleteOwnAuthProvider(ctx, params interface{}) *gomock.Call {
+func (mr *MockAPIInterfaceMockRecorder) DeleteOwnAuthProvider(ctx, params any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteOwnAuthProvider", reflect.TypeOf((*MockAPIInterface)(nil).DeleteOwnAuthProvider), ctx, params)
 }
@@ -175,7 +175,7 @@ func (m *MockAPIInterface) DeleteSSHPublicKey(ctx context.Context, id string) er
 }
 
 // DeleteSSHPublicKey indicates an expected call of DeleteSSHPublicKey.
-func (mr *MockAPIInterfaceMockRecorder) DeleteSSHPublicKey(ctx, id interface{}) *gomock.Call {
+func (mr *MockAPIInterfaceMockRecorder) DeleteSSHPublicKey(ctx, id any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteSSHPublicKey", reflect.TypeOf((*MockAPIInterface)(nil).DeleteSSHPublicKey), ctx, id)
 }
@@ -189,7 +189,7 @@ func (m *MockAPIInterface) DeleteWorkspace(ctx context.Context, id string) error
 }
 
 // DeleteWorkspace indicates an expected call of DeleteWorkspace.
-func (mr *MockAPIInterfaceMockRecorder) DeleteWorkspace(ctx, id interface{}) *gomock.Call {
+func (mr *MockAPIInterfaceMockRecorder) DeleteWorkspace(ctx, id any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteWorkspace", reflect.TypeOf((*MockAPIInterface)(nil).DeleteWorkspace), ctx, id)
 }
@@ -204,7 +204,7 @@ func (m *MockAPIInterface) GenerateNewGitpodToken(ctx context.Context, options *
 }
 
 // GenerateNewGitpodToken indicates an expected call of GenerateNewGitpodToken.
-func (mr *MockAPIInterfaceMockRecorder) GenerateNewGitpodToken(ctx, options interface{}) *gomock.Call {
+func (mr *MockAPIInterfaceMockRecorder) GenerateNewGitpodToken(ctx, options any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GenerateNewGitpodToken", reflect.TypeOf((*MockAPIInterface)(nil).GenerateNewGitpodToken), ctx, options)
 }
@@ -219,7 +219,7 @@ func (m *MockAPIInterface) GetAuthProviders(ctx context.Context) ([]*AuthProvide
 }
 
 // GetAuthProviders indicates an expected call of GetAuthProviders.
-func (mr *MockAPIInterfaceMockRecorder) GetAuthProviders(ctx interface{}) *gomock.Call {
+func (mr *MockAPIInterfaceMockRecorder) GetAuthProviders(ctx any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAuthProviders", reflect.TypeOf((*MockAPIInterface)(nil).GetAuthProviders), ctx)
 }
@@ -234,7 +234,7 @@ func (m *MockAPIInterface) GetClientRegion(ctx context.Context) (string, error) 
 }
 
 // GetClientRegion indicates an expected call of GetClientRegion.
-func (mr *MockAPIInterfaceMockRecorder) GetClientRegion(ctx interface{}) *gomock.Call {
+func (mr *MockAPIInterfaceMockRecorder) GetClientRegion(ctx any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetClientRegion", reflect.TypeOf((*MockAPIInterface)(nil).GetClientRegion), ctx)
 }
@@ -249,7 +249,7 @@ func (m *MockAPIInterface) GetConfiguration(ctx context.Context) (*Configuration
 }
 
 // GetConfiguration indicates an expected call of GetConfiguration.
-func (mr *MockAPIInterfaceMockRecorder) GetConfiguration(ctx interface{}) *gomock.Call {
+func (mr *MockAPIInterfaceMockRecorder) GetConfiguration(ctx any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetConfiguration", reflect.TypeOf((*MockAPIInterface)(nil).GetConfiguration), ctx)
 }
@@ -264,7 +264,7 @@ func (m *MockAPIInterface) GetContentBlobDownloadURL(ctx context.Context, name s
 }
 
 // GetContentBlobDownloadURL indicates an expected call of GetContentBlobDownloadURL.
-func (mr *MockAPIInterfaceMockRecorder) GetContentBlobDownloadURL(ctx, name interface{}) *gomock.Call {
+func (mr *MockAPIInterfaceMockRecorder) GetContentBlobDownloadURL(ctx, name any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetContentBlobDownloadURL", reflect.TypeOf((*MockAPIInterface)(nil).GetContentBlobDownloadURL), ctx, name)
 }
@@ -279,7 +279,7 @@ func (m *MockAPIInterface) GetContentBlobUploadURL(ctx context.Context, name str
 }
 
 // GetContentBlobUploadURL indicates an expected call of GetContentBlobUploadURL.
-func (mr *MockAPIInterfaceMockRecorder) GetContentBlobUploadURL(ctx, name interface{}) *gomock.Call {
+func (mr *MockAPIInterfaceMockRecorder) GetContentBlobUploadURL(ctx, name any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetContentBlobUploadURL", reflect.TypeOf((*MockAPIInterface)(nil).GetContentBlobUploadURL), ctx, name)
 }
@@ -294,7 +294,7 @@ func (m *MockAPIInterface) GetEnvVars(ctx context.Context) ([]*UserEnvVarValue, 
 }
 
 // GetEnvVars indicates an expected call of GetEnvVars.
-func (mr *MockAPIInterfaceMockRecorder) GetEnvVars(ctx interface{}) *gomock.Call {
+func (mr *MockAPIInterfaceMockRecorder) GetEnvVars(ctx any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetEnvVars", reflect.TypeOf((*MockAPIInterface)(nil).GetEnvVars), ctx)
 }
@@ -309,7 +309,7 @@ func (m *MockAPIInterface) GetFeaturedRepositories(ctx context.Context) ([]*Whit
 }
 
 // GetFeaturedRepositories indicates an expected call of GetFeaturedRepositories.
-func (mr *MockAPIInterfaceMockRecorder) GetFeaturedRepositories(ctx interface{}) *gomock.Call {
+func (mr *MockAPIInterfaceMockRecorder) GetFeaturedRepositories(ctx any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetFeaturedRepositories", reflect.TypeOf((*MockAPIInterface)(nil).GetFeaturedRepositories), ctx)
 }
@@ -324,7 +324,7 @@ func (m *MockAPIInterface) GetGitpodTokenScopes(ctx context.Context, tokenHash s
 }
 
 // GetGitpodTokenScopes indicates an expected call of GetGitpodTokenScopes.
-func (mr *MockAPIInterfaceMockRecorder) GetGitpodTokenScopes(ctx, tokenHash interface{}) *gomock.Call {
+func (mr *MockAPIInterfaceMockRecorder) GetGitpodTokenScopes(ctx, tokenHash any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetGitpodTokenScopes", reflect.TypeOf((*MockAPIInterface)(nil).GetGitpodTokenScopes), ctx, tokenHash)
 }
@@ -339,7 +339,7 @@ func (m *MockAPIInterface) GetGitpodTokens(ctx context.Context) ([]*APIToken, er
 }
 
 // GetGitpodTokens indicates an expected call of GetGitpodTokens.
-func (mr *MockAPIInterfaceMockRecorder) GetGitpodTokens(ctx interface{}) *gomock.Call {
+func (mr *MockAPIInterfaceMockRecorder) GetGitpodTokens(ctx any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetGitpodTokens", reflect.TypeOf((*MockAPIInterface)(nil).GetGitpodTokens), ctx)
 }
@@ -354,7 +354,7 @@ func (m *MockAPIInterface) GetLayout(ctx context.Context, workspaceID string) (s
 }
 
 // GetLayout indicates an expected call of GetLayout.
-func (mr *MockAPIInterfaceMockRecorder) GetLayout(ctx, workspaceID interface{}) *gomock.Call {
+func (mr *MockAPIInterfaceMockRecorder) GetLayout(ctx, workspaceID any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetLayout", reflect.TypeOf((*MockAPIInterface)(nil).GetLayout), ctx, workspaceID)
 }
@@ -369,7 +369,7 @@ func (m *MockAPIInterface) GetLoggedInUser(ctx context.Context) (*User, error) {
 }
 
 // GetLoggedInUser indicates an expected call of GetLoggedInUser.
-func (mr *MockAPIInterfaceMockRecorder) GetLoggedInUser(ctx interface{}) *gomock.Call {
+func (mr *MockAPIInterfaceMockRecorder) GetLoggedInUser(ctx any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetLoggedInUser", reflect.TypeOf((*MockAPIInterface)(nil).GetLoggedInUser), ctx)
 }
@@ -384,7 +384,7 @@ func (m *MockAPIInterface) GetOpenPorts(ctx context.Context, workspaceID string)
 }
 
 // GetOpenPorts indicates an expected call of GetOpenPorts.
-func (mr *MockAPIInterfaceMockRecorder) GetOpenPorts(ctx, workspaceID interface{}) *gomock.Call {
+func (mr *MockAPIInterfaceMockRecorder) GetOpenPorts(ctx, workspaceID any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetOpenPorts", reflect.TypeOf((*MockAPIInterface)(nil).GetOpenPorts), ctx, workspaceID)
 }
@@ -399,7 +399,7 @@ func (m *MockAPIInterface) GetOwnAuthProviders(ctx context.Context) ([]*AuthProv
 }
 
 // GetOwnAuthProviders indicates an expected call of GetOwnAuthProviders.
-func (mr *MockAPIInterfaceMockRecorder) GetOwnAuthProviders(ctx interface{}) *gomock.Call {
+func (mr *MockAPIInterfaceMockRecorder) GetOwnAuthProviders(ctx any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetOwnAuthProviders", reflect.TypeOf((*MockAPIInterface)(nil).GetOwnAuthProviders), ctx)
 }
@@ -414,7 +414,7 @@ func (m *MockAPIInterface) GetOwnerToken(ctx context.Context, workspaceID string
 }
 
 // GetOwnerToken indicates an expected call of GetOwnerToken.
-func (mr *MockAPIInterfaceMockRecorder) GetOwnerToken(ctx, workspaceID interface{}) *gomock.Call {
+func (mr *MockAPIInterfaceMockRecorder) GetOwnerToken(ctx, workspaceID any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetOwnerToken", reflect.TypeOf((*MockAPIInterface)(nil).GetOwnerToken), ctx, workspaceID)
 }
@@ -429,7 +429,7 @@ func (m *MockAPIInterface) GetPortAuthenticationToken(ctx context.Context, works
 }
 
 // GetPortAuthenticationToken indicates an expected call of GetPortAuthenticationToken.
-func (mr *MockAPIInterfaceMockRecorder) GetPortAuthenticationToken(ctx, workspaceID interface{}) *gomock.Call {
+func (mr *MockAPIInterfaceMockRecorder) GetPortAuthenticationToken(ctx, workspaceID any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetPortAuthenticationToken", reflect.TypeOf((*MockAPIInterface)(nil).GetPortAuthenticationToken), ctx, workspaceID)
 }
@@ -444,7 +444,7 @@ func (m *MockAPIInterface) GetSSHPublicKeys(ctx context.Context) ([]*UserSSHPubl
 }
 
 // GetSSHPublicKeys indicates an expected call of GetSSHPublicKeys.
-func (mr *MockAPIInterfaceMockRecorder) GetSSHPublicKeys(ctx interface{}) *gomock.Call {
+func (mr *MockAPIInterfaceMockRecorder) GetSSHPublicKeys(ctx any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSSHPublicKeys", reflect.TypeOf((*MockAPIInterface)(nil).GetSSHPublicKeys), ctx)
 }
@@ -459,7 +459,7 @@ func (m *MockAPIInterface) GetSnapshots(ctx context.Context, workspaceID string)
 }
 
 // GetSnapshots indicates an expected call of GetSnapshots.
-func (mr *MockAPIInterfaceMockRecorder) GetSnapshots(ctx, workspaceID interface{}) *gomock.Call {
+func (mr *MockAPIInterfaceMockRecorder) GetSnapshots(ctx, workspaceID any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSnapshots", reflect.TypeOf((*MockAPIInterface)(nil).GetSnapshots), ctx, workspaceID)
 }
@@ -474,7 +474,7 @@ func (m *MockAPIInterface) GetSupportedWorkspaceClasses(ctx context.Context) ([]
 }
 
 // GetSupportedWorkspaceClasses indicates an expected call of GetSupportedWorkspaceClasses.
-func (mr *MockAPIInterfaceMockRecorder) GetSupportedWorkspaceClasses(ctx interface{}) *gomock.Call {
+func (mr *MockAPIInterfaceMockRecorder) GetSupportedWorkspaceClasses(ctx any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSupportedWorkspaceClasses", reflect.TypeOf((*MockAPIInterface)(nil).GetSupportedWorkspaceClasses), ctx)
 }
@@ -489,7 +489,7 @@ func (m *MockAPIInterface) GetToken(ctx context.Context, query *GetTokenSearchOp
 }
 
 // GetToken indicates an expected call of GetToken.
-func (mr *MockAPIInterfaceMockRecorder) GetToken(ctx, query interface{}) *gomock.Call {
+func (mr *MockAPIInterfaceMockRecorder) GetToken(ctx, query any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetToken", reflect.TypeOf((*MockAPIInterface)(nil).GetToken), ctx, query)
 }
@@ -504,7 +504,7 @@ func (m *MockAPIInterface) GetUserStorageResource(ctx context.Context, options *
 }
 
 // GetUserStorageResource indicates an expected call of GetUserStorageResource.
-func (mr *MockAPIInterfaceMockRecorder) GetUserStorageResource(ctx, options interface{}) *gomock.Call {
+func (mr *MockAPIInterfaceMockRecorder) GetUserStorageResource(ctx, options any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetUserStorageResource", reflect.TypeOf((*MockAPIInterface)(nil).GetUserStorageResource), ctx, options)
 }
@@ -519,7 +519,7 @@ func (m *MockAPIInterface) GetWorkspace(ctx context.Context, id string) (*Worksp
 }
 
 // GetWorkspace indicates an expected call of GetWorkspace.
-func (mr *MockAPIInterfaceMockRecorder) GetWorkspace(ctx, id interface{}) *gomock.Call {
+func (mr *MockAPIInterfaceMockRecorder) GetWorkspace(ctx, id any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetWorkspace", reflect.TypeOf((*MockAPIInterface)(nil).GetWorkspace), ctx, id)
 }
@@ -534,7 +534,7 @@ func (m *MockAPIInterface) GetWorkspaceOwner(ctx context.Context, workspaceID st
 }
 
 // GetWorkspaceOwner indicates an expected call of GetWorkspaceOwner.
-func (mr *MockAPIInterfaceMockRecorder) GetWorkspaceOwner(ctx, workspaceID interface{}) *gomock.Call {
+func (mr *MockAPIInterfaceMockRecorder) GetWorkspaceOwner(ctx, workspaceID any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetWorkspaceOwner", reflect.TypeOf((*MockAPIInterface)(nil).GetWorkspaceOwner), ctx, workspaceID)
 }
@@ -549,7 +549,7 @@ func (m *MockAPIInterface) GetWorkspaceTimeout(ctx context.Context, workspaceID 
 }
 
 // GetWorkspaceTimeout indicates an expected call of GetWorkspaceTimeout.
-func (mr *MockAPIInterfaceMockRecorder) GetWorkspaceTimeout(ctx, workspaceID interface{}) *gomock.Call {
+func (mr *MockAPIInterfaceMockRecorder) GetWorkspaceTimeout(ctx, workspaceID any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetWorkspaceTimeout", reflect.TypeOf((*MockAPIInterface)(nil).GetWorkspaceTimeout), ctx, workspaceID)
 }
@@ -564,7 +564,7 @@ func (m *MockAPIInterface) GetWorkspaceUsers(ctx context.Context, workspaceID st
 }
 
 // GetWorkspaceUsers indicates an expected call of GetWorkspaceUsers.
-func (mr *MockAPIInterfaceMockRecorder) GetWorkspaceUsers(ctx, workspaceID interface{}) *gomock.Call {
+func (mr *MockAPIInterfaceMockRecorder) GetWorkspaceUsers(ctx, workspaceID any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetWorkspaceUsers", reflect.TypeOf((*MockAPIInterface)(nil).GetWorkspaceUsers), ctx, workspaceID)
 }
@@ -579,7 +579,7 @@ func (m *MockAPIInterface) GetWorkspaces(ctx context.Context, options *GetWorksp
 }
 
 // GetWorkspaces indicates an expected call of GetWorkspaces.
-func (mr *MockAPIInterfaceMockRecorder) GetWorkspaces(ctx, options interface{}) *gomock.Call {
+func (mr *MockAPIInterfaceMockRecorder) GetWorkspaces(ctx, options any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetWorkspaces", reflect.TypeOf((*MockAPIInterface)(nil).GetWorkspaces), ctx, options)
 }
@@ -594,7 +594,7 @@ func (m *MockAPIInterface) GuessGitTokenScopes(ctx context.Context, params *Gues
 }
 
 // GuessGitTokenScopes indicates an expected call of GuessGitTokenScopes.
-func (mr *MockAPIInterfaceMockRecorder) GuessGitTokenScopes(ctx, params interface{}) *gomock.Call {
+func (mr *MockAPIInterfaceMockRecorder) GuessGitTokenScopes(ctx, params any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GuessGitTokenScopes", reflect.TypeOf((*MockAPIInterface)(nil).GuessGitTokenScopes), ctx, params)
 }
@@ -609,7 +609,7 @@ func (m *MockAPIInterface) HasPermission(ctx context.Context, permission *Permis
 }
 
 // HasPermission indicates an expected call of HasPermission.
-func (mr *MockAPIInterfaceMockRecorder) HasPermission(ctx, permission interface{}) *gomock.Call {
+func (mr *MockAPIInterfaceMockRecorder) HasPermission(ctx, permission any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HasPermission", reflect.TypeOf((*MockAPIInterface)(nil).HasPermission), ctx, permission)
 }
@@ -624,7 +624,7 @@ func (m *MockAPIInterface) HasSSHPublicKey(ctx context.Context) (bool, error) {
 }
 
 // HasSSHPublicKey indicates an expected call of HasSSHPublicKey.
-func (mr *MockAPIInterfaceMockRecorder) HasSSHPublicKey(ctx interface{}) *gomock.Call {
+func (mr *MockAPIInterfaceMockRecorder) HasSSHPublicKey(ctx any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HasSSHPublicKey", reflect.TypeOf((*MockAPIInterface)(nil).HasSSHPublicKey), ctx)
 }
@@ -639,7 +639,7 @@ func (m *MockAPIInterface) InstanceUpdates(ctx context.Context, instanceID strin
 }
 
 // InstanceUpdates indicates an expected call of InstanceUpdates.
-func (mr *MockAPIInterfaceMockRecorder) InstanceUpdates(ctx, instanceID interface{}) *gomock.Call {
+func (mr *MockAPIInterfaceMockRecorder) InstanceUpdates(ctx, instanceID any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InstanceUpdates", reflect.TypeOf((*MockAPIInterface)(nil).InstanceUpdates), ctx, instanceID)
 }
@@ -654,7 +654,7 @@ func (m *MockAPIInterface) IsPrebuildDone(ctx context.Context, pwsid string) (bo
 }
 
 // IsPrebuildDone indicates an expected call of IsPrebuildDone.
-func (mr *MockAPIInterfaceMockRecorder) IsPrebuildDone(ctx, pwsid interface{}) *gomock.Call {
+func (mr *MockAPIInterfaceMockRecorder) IsPrebuildDone(ctx, pwsid any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsPrebuildDone", reflect.TypeOf((*MockAPIInterface)(nil).IsPrebuildDone), ctx, pwsid)
 }
@@ -669,7 +669,7 @@ func (m *MockAPIInterface) IsWorkspaceOwner(ctx context.Context, workspaceID str
 }
 
 // IsWorkspaceOwner indicates an expected call of IsWorkspaceOwner.
-func (mr *MockAPIInterfaceMockRecorder) IsWorkspaceOwner(ctx, workspaceID interface{}) *gomock.Call {
+func (mr *MockAPIInterfaceMockRecorder) IsWorkspaceOwner(ctx, workspaceID any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsWorkspaceOwner", reflect.TypeOf((*MockAPIInterface)(nil).IsWorkspaceOwner), ctx, workspaceID)
 }
@@ -684,7 +684,7 @@ func (m *MockAPIInterface) OpenPort(ctx context.Context, workspaceID string, por
 }
 
 // OpenPort indicates an expected call of OpenPort.
-func (mr *MockAPIInterfaceMockRecorder) OpenPort(ctx, workspaceID, port interface{}) *gomock.Call {
+func (mr *MockAPIInterfaceMockRecorder) OpenPort(ctx, workspaceID, port any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "OpenPort", reflect.TypeOf((*MockAPIInterface)(nil).OpenPort), ctx, workspaceID, port)
 }
@@ -698,7 +698,7 @@ func (m *MockAPIInterface) RegisterGithubApp(ctx context.Context, installationID
 }
 
 // RegisterGithubApp indicates an expected call of RegisterGithubApp.
-func (mr *MockAPIInterfaceMockRecorder) RegisterGithubApp(ctx, installationID interface{}) *gomock.Call {
+func (mr *MockAPIInterfaceMockRecorder) RegisterGithubApp(ctx, installationID any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RegisterGithubApp", reflect.TypeOf((*MockAPIInterface)(nil).RegisterGithubApp), ctx, installationID)
 }
@@ -713,7 +713,7 @@ func (m *MockAPIInterface) SendFeedback(ctx context.Context, feedback string) (s
 }
 
 // SendFeedback indicates an expected call of SendFeedback.
-func (mr *MockAPIInterfaceMockRecorder) SendFeedback(ctx, feedback interface{}) *gomock.Call {
+func (mr *MockAPIInterfaceMockRecorder) SendFeedback(ctx, feedback any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SendFeedback", reflect.TypeOf((*MockAPIInterface)(nil).SendFeedback), ctx, feedback)
 }
@@ -727,7 +727,7 @@ func (m *MockAPIInterface) SendHeartBeat(ctx context.Context, options *SendHeart
 }
 
 // SendHeartBeat indicates an expected call of SendHeartBeat.
-func (mr *MockAPIInterfaceMockRecorder) SendHeartBeat(ctx, options interface{}) *gomock.Call {
+func (mr *MockAPIInterfaceMockRecorder) SendHeartBeat(ctx, options any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SendHeartBeat", reflect.TypeOf((*MockAPIInterface)(nil).SendHeartBeat), ctx, options)
 }
@@ -741,7 +741,7 @@ func (m *MockAPIInterface) SetEnvVar(ctx context.Context, variable *UserEnvVarVa
 }
 
 // SetEnvVar indicates an expected call of SetEnvVar.
-func (mr *MockAPIInterfaceMockRecorder) SetEnvVar(ctx, variable interface{}) *gomock.Call {
+func (mr *MockAPIInterfaceMockRecorder) SetEnvVar(ctx, variable any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetEnvVar", reflect.TypeOf((*MockAPIInterface)(nil).SetEnvVar), ctx, variable)
 }
@@ -755,7 +755,7 @@ func (m *MockAPIInterface) SetWorkspaceDescription(ctx context.Context, id, desc
 }
 
 // SetWorkspaceDescription indicates an expected call of SetWorkspaceDescription.
-func (mr *MockAPIInterfaceMockRecorder) SetWorkspaceDescription(ctx, id, desc interface{}) *gomock.Call {
+func (mr *MockAPIInterfaceMockRecorder) SetWorkspaceDescription(ctx, id, desc any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetWorkspaceDescription", reflect.TypeOf((*MockAPIInterface)(nil).SetWorkspaceDescription), ctx, id, desc)
 }
@@ -770,7 +770,7 @@ func (m *MockAPIInterface) SetWorkspaceTimeout(ctx context.Context, workspaceID 
 }
 
 // SetWorkspaceTimeout indicates an expected call of SetWorkspaceTimeout.
-func (mr *MockAPIInterfaceMockRecorder) SetWorkspaceTimeout(ctx, workspaceID, duration interface{}) *gomock.Call {
+func (mr *MockAPIInterfaceMockRecorder) SetWorkspaceTimeout(ctx, workspaceID, duration any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetWorkspaceTimeout", reflect.TypeOf((*MockAPIInterface)(nil).SetWorkspaceTimeout), ctx, workspaceID, duration)
 }
@@ -785,7 +785,7 @@ func (m *MockAPIInterface) StartWorkspace(ctx context.Context, id string, option
 }
 
 // StartWorkspace indicates an expected call of StartWorkspace.
-func (mr *MockAPIInterfaceMockRecorder) StartWorkspace(ctx, id, options interface{}) *gomock.Call {
+func (mr *MockAPIInterfaceMockRecorder) StartWorkspace(ctx, id, options any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StartWorkspace", reflect.TypeOf((*MockAPIInterface)(nil).StartWorkspace), ctx, id, options)
 }
@@ -799,7 +799,7 @@ func (m *MockAPIInterface) StopWorkspace(ctx context.Context, id string) error {
 }
 
 // StopWorkspace indicates an expected call of StopWorkspace.
-func (mr *MockAPIInterfaceMockRecorder) StopWorkspace(ctx, id interface{}) *gomock.Call {
+func (mr *MockAPIInterfaceMockRecorder) StopWorkspace(ctx, id any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StopWorkspace", reflect.TypeOf((*MockAPIInterface)(nil).StopWorkspace), ctx, id)
 }
@@ -813,7 +813,7 @@ func (m *MockAPIInterface) StoreLayout(ctx context.Context, workspaceID, layoutD
 }
 
 // StoreLayout indicates an expected call of StoreLayout.
-func (mr *MockAPIInterfaceMockRecorder) StoreLayout(ctx, workspaceID, layoutData interface{}) *gomock.Call {
+func (mr *MockAPIInterfaceMockRecorder) StoreLayout(ctx, workspaceID, layoutData any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StoreLayout", reflect.TypeOf((*MockAPIInterface)(nil).StoreLayout), ctx, workspaceID, layoutData)
 }
@@ -828,7 +828,7 @@ func (m *MockAPIInterface) TakeSnapshot(ctx context.Context, options *TakeSnapsh
 }
 
 // TakeSnapshot indicates an expected call of TakeSnapshot.
-func (mr *MockAPIInterfaceMockRecorder) TakeSnapshot(ctx, options interface{}) *gomock.Call {
+func (mr *MockAPIInterfaceMockRecorder) TakeSnapshot(ctx, options any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TakeSnapshot", reflect.TypeOf((*MockAPIInterface)(nil).TakeSnapshot), ctx, options)
 }
@@ -842,7 +842,7 @@ func (m *MockAPIInterface) TrackEvent(ctx context.Context, event *RemoteTrackMes
 }
 
 // TrackEvent indicates an expected call of TrackEvent.
-func (mr *MockAPIInterfaceMockRecorder) TrackEvent(ctx, event interface{}) *gomock.Call {
+func (mr *MockAPIInterfaceMockRecorder) TrackEvent(ctx, event any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TrackEvent", reflect.TypeOf((*MockAPIInterface)(nil).TrackEvent), ctx, event)
 }
@@ -857,7 +857,7 @@ func (m *MockAPIInterface) UpdateLoggedInUser(ctx context.Context, user *User) (
 }
 
 // UpdateLoggedInUser indicates an expected call of UpdateLoggedInUser.
-func (mr *MockAPIInterfaceMockRecorder) UpdateLoggedInUser(ctx, user interface{}) *gomock.Call {
+func (mr *MockAPIInterfaceMockRecorder) UpdateLoggedInUser(ctx, user any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateLoggedInUser", reflect.TypeOf((*MockAPIInterface)(nil).UpdateLoggedInUser), ctx, user)
 }
@@ -871,7 +871,7 @@ func (m *MockAPIInterface) UpdateOwnAuthProvider(ctx context.Context, params *Up
 }
 
 // UpdateOwnAuthProvider indicates an expected call of UpdateOwnAuthProvider.
-func (mr *MockAPIInterfaceMockRecorder) UpdateOwnAuthProvider(ctx, params interface{}) *gomock.Call {
+func (mr *MockAPIInterfaceMockRecorder) UpdateOwnAuthProvider(ctx, params any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateOwnAuthProvider", reflect.TypeOf((*MockAPIInterface)(nil).UpdateOwnAuthProvider), ctx, params)
 }
@@ -885,7 +885,7 @@ func (m *MockAPIInterface) UpdateUserStorageResource(ctx context.Context, option
 }
 
 // UpdateUserStorageResource indicates an expected call of UpdateUserStorageResource.
-func (mr *MockAPIInterfaceMockRecorder) UpdateUserStorageResource(ctx, options interface{}) *gomock.Call {
+func (mr *MockAPIInterfaceMockRecorder) UpdateUserStorageResource(ctx, options any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateUserStorageResource", reflect.TypeOf((*MockAPIInterface)(nil).UpdateUserStorageResource), ctx, options)
 }
@@ -899,7 +899,7 @@ func (m *MockAPIInterface) UpdateWorkspaceUserPin(ctx context.Context, id string
 }
 
 // UpdateWorkspaceUserPin indicates an expected call of UpdateWorkspaceUserPin.
-func (mr *MockAPIInterfaceMockRecorder) UpdateWorkspaceUserPin(ctx, id, action interface{}) *gomock.Call {
+func (mr *MockAPIInterfaceMockRecorder) UpdateWorkspaceUserPin(ctx, id, action any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateWorkspaceUserPin", reflect.TypeOf((*MockAPIInterface)(nil).UpdateWorkspaceUserPin), ctx, id, action)
 }
@@ -913,7 +913,7 @@ func (m *MockAPIInterface) WaitForSnapshot(ctx context.Context, snapshotId strin
 }
 
 // WaitForSnapshot indicates an expected call of WaitForSnapshot.
-func (mr *MockAPIInterfaceMockRecorder) WaitForSnapshot(ctx, snapshotId interface{}) *gomock.Call {
+func (mr *MockAPIInterfaceMockRecorder) WaitForSnapshot(ctx, snapshotId any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WaitForSnapshot", reflect.TypeOf((*MockAPIInterface)(nil).WaitForSnapshot), ctx, snapshotId)
 }
@@ -927,7 +927,7 @@ func (m *MockAPIInterface) WatchWorkspaceImageBuildLogs(ctx context.Context, wor
 }
 
 // WatchWorkspaceImageBuildLogs indicates an expected call of WatchWorkspaceImageBuildLogs.
-func (mr *MockAPIInterfaceMockRecorder) WatchWorkspaceImageBuildLogs(ctx, workspaceID interface{}) *gomock.Call {
+func (mr *MockAPIInterfaceMockRecorder) WatchWorkspaceImageBuildLogs(ctx, workspaceID any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WatchWorkspaceImageBuildLogs", reflect.TypeOf((*MockAPIInterface)(nil).WatchWorkspaceImageBuildLogs), ctx, workspaceID)
 }

--- a/components/gitpod-protocol/go/reconnecting-ws.go
+++ b/components/gitpod-protocol/go/reconnecting-ws.go
@@ -131,7 +131,7 @@ func isJSONError(err error) bool {
 
 // WriteObject writes the JSON encoding of v as a message.
 // See the documentation for encoding/json Marshal for details about the conversion of Go values to JSON.
-func (rc *ReconnectingWebsocket) WriteObject(v interface{}) error {
+func (rc *ReconnectingWebsocket) WriteObject(v any) error {
 	return rc.EnsureConnection(func(conn *WebsocketConnection) (bool, error) {
 		err := conn.WriteJSON(v)
 		closed := err != nil && !isJSONError(err)
@@ -141,7 +141,7 @@ func (rc *ReconnectingWebsocket) WriteObject(v interface{}) error {
 
 // ReadObject reads the next JSON-encoded message from the connection and stores it in the value pointed to by v.
 // See the documentation for the encoding/json Unmarshal function for details about the conversion of JSON to a Go value.
-func (rc *ReconnectingWebsocket) ReadObject(v interface{}) error {
+func (rc *ReconnectingWebsocket) ReadObject(v any) error {
 	return rc.EnsureConnection(func(conn *WebsocketConnection) (bool, error) {
 		err := conn.ReadJSON(v)
 		closed := err != nil && !isJSONError(err)

--- a/components/ide-metrics-api/go/idemetrics.pb.go
+++ b/components/ide-metrics-api/go/idemetrics.pb.go
@@ -302,7 +302,7 @@ func file_idemetrics_proto_rawDescGZIP() []byte {
 }
 
 var file_idemetrics_proto_msgTypes = make([]protoimpl.MessageInfo, 6)
-var file_idemetrics_proto_goTypes = []interface{}{
+var file_idemetrics_proto_goTypes = []any{
 	(*AddCounterRequest)(nil),        // 0: ide_metrics_api.AddCounterRequest
 	(*AddCounterResponse)(nil),       // 1: ide_metrics_api.AddCounterResponse
 	(*ObserveHistogramRequest)(nil),  // 2: ide_metrics_api.ObserveHistogramRequest
@@ -330,7 +330,7 @@ func file_idemetrics_proto_init() {
 		return
 	}
 	if !protoimpl.UnsafeEnabled {
-		file_idemetrics_proto_msgTypes[0].Exporter = func(v interface{}, i int) interface{} {
+		file_idemetrics_proto_msgTypes[0].Exporter = func(v any, i int) any {
 			switch v := v.(*AddCounterRequest); i {
 			case 0:
 				return &v.state
@@ -342,7 +342,7 @@ func file_idemetrics_proto_init() {
 				return nil
 			}
 		}
-		file_idemetrics_proto_msgTypes[1].Exporter = func(v interface{}, i int) interface{} {
+		file_idemetrics_proto_msgTypes[1].Exporter = func(v any, i int) any {
 			switch v := v.(*AddCounterResponse); i {
 			case 0:
 				return &v.state
@@ -354,7 +354,7 @@ func file_idemetrics_proto_init() {
 				return nil
 			}
 		}
-		file_idemetrics_proto_msgTypes[2].Exporter = func(v interface{}, i int) interface{} {
+		file_idemetrics_proto_msgTypes[2].Exporter = func(v any, i int) any {
 			switch v := v.(*ObserveHistogramRequest); i {
 			case 0:
 				return &v.state
@@ -366,7 +366,7 @@ func file_idemetrics_proto_init() {
 				return nil
 			}
 		}
-		file_idemetrics_proto_msgTypes[3].Exporter = func(v interface{}, i int) interface{} {
+		file_idemetrics_proto_msgTypes[3].Exporter = func(v any, i int) any {
 			switch v := v.(*ObserveHistogramResponse); i {
 			case 0:
 				return &v.state
@@ -379,7 +379,7 @@ func file_idemetrics_proto_init() {
 			}
 		}
 	}
-	file_idemetrics_proto_msgTypes[0].OneofWrappers = []interface{}{}
+	file_idemetrics_proto_msgTypes[0].OneofWrappers = []any{}
 	type x struct{}
 	out := protoimpl.TypeBuilder{
 		File: protoimpl.DescBuilder{

--- a/components/ide-metrics-api/go/idemetrics_grpc.pb.go
+++ b/components/ide-metrics-api/go/idemetrics_grpc.pb.go
@@ -88,7 +88,7 @@ func RegisterMetricsServiceServer(s grpc.ServiceRegistrar, srv MetricsServiceSer
 	s.RegisterService(&MetricsService_ServiceDesc, srv)
 }
 
-func _MetricsService_AddCounter_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+func _MetricsService_AddCounter_Handler(srv any, ctx context.Context, dec func(any) error, interceptor grpc.UnaryServerInterceptor) (any, error) {
 	in := new(AddCounterRequest)
 	if err := dec(in); err != nil {
 		return nil, err
@@ -100,13 +100,13 @@ func _MetricsService_AddCounter_Handler(srv interface{}, ctx context.Context, de
 		Server:     srv,
 		FullMethod: "/ide_metrics_api.MetricsService/AddCounter",
 	}
-	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+	handler := func(ctx context.Context, req any) (any, error) {
 		return srv.(MetricsServiceServer).AddCounter(ctx, req.(*AddCounterRequest))
 	}
 	return interceptor(ctx, in, info, handler)
 }
 
-func _MetricsService_ObserveHistogram_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+func _MetricsService_ObserveHistogram_Handler(srv any, ctx context.Context, dec func(any) error, interceptor grpc.UnaryServerInterceptor) (any, error) {
 	in := new(ObserveHistogramRequest)
 	if err := dec(in); err != nil {
 		return nil, err
@@ -118,7 +118,7 @@ func _MetricsService_ObserveHistogram_Handler(srv interface{}, ctx context.Conte
 		Server:     srv,
 		FullMethod: "/ide_metrics_api.MetricsService/ObserveHistogram",
 	}
-	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+	handler := func(ctx context.Context, req any) (any, error) {
 		return srv.(MetricsServiceServer).ObserveHistogram(ctx, req.(*ObserveHistogramRequest))
 	}
 	return interceptor(ctx, in, info, handler)

--- a/components/image-builder-api/go/config/config.go
+++ b/components/image-builder-api/go/config/config.go
@@ -96,5 +96,5 @@ type WorkspaceManagerConfig struct {
 	TLS     TLS    `json:"tls,omitempty"`
 	// expected to be a wsmanapi.WorkspaceManagerClient - use to avoid dependency on wsmanapi
 	// this field is used for testing only
-	Client interface{} `json:"-"`
+	Client any `json:"-"`
 }

--- a/components/image-builder-api/go/imgbuilder.pb.go
+++ b/components/image-builder-api/go/imgbuilder.pb.go
@@ -1379,7 +1379,7 @@ func file_imgbuilder_proto_rawDescGZIP() []byte {
 
 var file_imgbuilder_proto_enumTypes = make([]protoimpl.EnumInfo, 1)
 var file_imgbuilder_proto_msgTypes = make([]protoimpl.MessageInfo, 20)
-var file_imgbuilder_proto_goTypes = []interface{}{
+var file_imgbuilder_proto_goTypes = []any{
 	(BuildStatus)(0),                      // 0: builder.BuildStatus
 	(*BuildSource)(nil),                   // 1: builder.BuildSource
 	(*BuildSourceReference)(nil),          // 2: builder.BuildSourceReference
@@ -1445,7 +1445,7 @@ func file_imgbuilder_proto_init() {
 		return
 	}
 	if !protoimpl.UnsafeEnabled {
-		file_imgbuilder_proto_msgTypes[0].Exporter = func(v interface{}, i int) interface{} {
+		file_imgbuilder_proto_msgTypes[0].Exporter = func(v any, i int) any {
 			switch v := v.(*BuildSource); i {
 			case 0:
 				return &v.state
@@ -1457,7 +1457,7 @@ func file_imgbuilder_proto_init() {
 				return nil
 			}
 		}
-		file_imgbuilder_proto_msgTypes[1].Exporter = func(v interface{}, i int) interface{} {
+		file_imgbuilder_proto_msgTypes[1].Exporter = func(v any, i int) any {
 			switch v := v.(*BuildSourceReference); i {
 			case 0:
 				return &v.state
@@ -1469,7 +1469,7 @@ func file_imgbuilder_proto_init() {
 				return nil
 			}
 		}
-		file_imgbuilder_proto_msgTypes[2].Exporter = func(v interface{}, i int) interface{} {
+		file_imgbuilder_proto_msgTypes[2].Exporter = func(v any, i int) any {
 			switch v := v.(*BuildSourceDockerfile); i {
 			case 0:
 				return &v.state
@@ -1481,7 +1481,7 @@ func file_imgbuilder_proto_init() {
 				return nil
 			}
 		}
-		file_imgbuilder_proto_msgTypes[3].Exporter = func(v interface{}, i int) interface{} {
+		file_imgbuilder_proto_msgTypes[3].Exporter = func(v any, i int) any {
 			switch v := v.(*ResolveBaseImageRequest); i {
 			case 0:
 				return &v.state
@@ -1493,7 +1493,7 @@ func file_imgbuilder_proto_init() {
 				return nil
 			}
 		}
-		file_imgbuilder_proto_msgTypes[4].Exporter = func(v interface{}, i int) interface{} {
+		file_imgbuilder_proto_msgTypes[4].Exporter = func(v any, i int) any {
 			switch v := v.(*ResolveBaseImageResponse); i {
 			case 0:
 				return &v.state
@@ -1505,7 +1505,7 @@ func file_imgbuilder_proto_init() {
 				return nil
 			}
 		}
-		file_imgbuilder_proto_msgTypes[5].Exporter = func(v interface{}, i int) interface{} {
+		file_imgbuilder_proto_msgTypes[5].Exporter = func(v any, i int) any {
 			switch v := v.(*ResolveWorkspaceImageRequest); i {
 			case 0:
 				return &v.state
@@ -1517,7 +1517,7 @@ func file_imgbuilder_proto_init() {
 				return nil
 			}
 		}
-		file_imgbuilder_proto_msgTypes[6].Exporter = func(v interface{}, i int) interface{} {
+		file_imgbuilder_proto_msgTypes[6].Exporter = func(v any, i int) any {
 			switch v := v.(*ResolveWorkspaceImageResponse); i {
 			case 0:
 				return &v.state
@@ -1529,7 +1529,7 @@ func file_imgbuilder_proto_init() {
 				return nil
 			}
 		}
-		file_imgbuilder_proto_msgTypes[7].Exporter = func(v interface{}, i int) interface{} {
+		file_imgbuilder_proto_msgTypes[7].Exporter = func(v any, i int) any {
 			switch v := v.(*BuildRequest); i {
 			case 0:
 				return &v.state
@@ -1541,7 +1541,7 @@ func file_imgbuilder_proto_init() {
 				return nil
 			}
 		}
-		file_imgbuilder_proto_msgTypes[8].Exporter = func(v interface{}, i int) interface{} {
+		file_imgbuilder_proto_msgTypes[8].Exporter = func(v any, i int) any {
 			switch v := v.(*BuildRegistryAuth); i {
 			case 0:
 				return &v.state
@@ -1553,7 +1553,7 @@ func file_imgbuilder_proto_init() {
 				return nil
 			}
 		}
-		file_imgbuilder_proto_msgTypes[9].Exporter = func(v interface{}, i int) interface{} {
+		file_imgbuilder_proto_msgTypes[9].Exporter = func(v any, i int) any {
 			switch v := v.(*BuildRegistryAuthTotal); i {
 			case 0:
 				return &v.state
@@ -1565,7 +1565,7 @@ func file_imgbuilder_proto_init() {
 				return nil
 			}
 		}
-		file_imgbuilder_proto_msgTypes[10].Exporter = func(v interface{}, i int) interface{} {
+		file_imgbuilder_proto_msgTypes[10].Exporter = func(v any, i int) any {
 			switch v := v.(*BuildRegistryAuthSelective); i {
 			case 0:
 				return &v.state
@@ -1577,7 +1577,7 @@ func file_imgbuilder_proto_init() {
 				return nil
 			}
 		}
-		file_imgbuilder_proto_msgTypes[11].Exporter = func(v interface{}, i int) interface{} {
+		file_imgbuilder_proto_msgTypes[11].Exporter = func(v any, i int) any {
 			switch v := v.(*BuildResponse); i {
 			case 0:
 				return &v.state
@@ -1589,7 +1589,7 @@ func file_imgbuilder_proto_init() {
 				return nil
 			}
 		}
-		file_imgbuilder_proto_msgTypes[12].Exporter = func(v interface{}, i int) interface{} {
+		file_imgbuilder_proto_msgTypes[12].Exporter = func(v any, i int) any {
 			switch v := v.(*LogsRequest); i {
 			case 0:
 				return &v.state
@@ -1601,7 +1601,7 @@ func file_imgbuilder_proto_init() {
 				return nil
 			}
 		}
-		file_imgbuilder_proto_msgTypes[13].Exporter = func(v interface{}, i int) interface{} {
+		file_imgbuilder_proto_msgTypes[13].Exporter = func(v any, i int) any {
 			switch v := v.(*LogsResponse); i {
 			case 0:
 				return &v.state
@@ -1613,7 +1613,7 @@ func file_imgbuilder_proto_init() {
 				return nil
 			}
 		}
-		file_imgbuilder_proto_msgTypes[14].Exporter = func(v interface{}, i int) interface{} {
+		file_imgbuilder_proto_msgTypes[14].Exporter = func(v any, i int) any {
 			switch v := v.(*ListBuildsRequest); i {
 			case 0:
 				return &v.state
@@ -1625,7 +1625,7 @@ func file_imgbuilder_proto_init() {
 				return nil
 			}
 		}
-		file_imgbuilder_proto_msgTypes[15].Exporter = func(v interface{}, i int) interface{} {
+		file_imgbuilder_proto_msgTypes[15].Exporter = func(v any, i int) any {
 			switch v := v.(*ListBuildsResponse); i {
 			case 0:
 				return &v.state
@@ -1637,7 +1637,7 @@ func file_imgbuilder_proto_init() {
 				return nil
 			}
 		}
-		file_imgbuilder_proto_msgTypes[16].Exporter = func(v interface{}, i int) interface{} {
+		file_imgbuilder_proto_msgTypes[16].Exporter = func(v any, i int) any {
 			switch v := v.(*BuildInfo); i {
 			case 0:
 				return &v.state
@@ -1649,7 +1649,7 @@ func file_imgbuilder_proto_init() {
 				return nil
 			}
 		}
-		file_imgbuilder_proto_msgTypes[17].Exporter = func(v interface{}, i int) interface{} {
+		file_imgbuilder_proto_msgTypes[17].Exporter = func(v any, i int) any {
 			switch v := v.(*LogInfo); i {
 			case 0:
 				return &v.state
@@ -1662,11 +1662,11 @@ func file_imgbuilder_proto_init() {
 			}
 		}
 	}
-	file_imgbuilder_proto_msgTypes[0].OneofWrappers = []interface{}{
+	file_imgbuilder_proto_msgTypes[0].OneofWrappers = []any{
 		(*BuildSource_Ref)(nil),
 		(*BuildSource_File)(nil),
 	}
-	file_imgbuilder_proto_msgTypes[8].OneofWrappers = []interface{}{
+	file_imgbuilder_proto_msgTypes[8].OneofWrappers = []any{
 		(*BuildRegistryAuth_Total)(nil),
 		(*BuildRegistryAuth_Selective)(nil),
 	}

--- a/components/image-builder-api/go/imgbuilder_grpc.pb.go
+++ b/components/image-builder-api/go/imgbuilder_grpc.pb.go
@@ -188,7 +188,7 @@ func RegisterImageBuilderServer(s grpc.ServiceRegistrar, srv ImageBuilderServer)
 	s.RegisterService(&ImageBuilder_ServiceDesc, srv)
 }
 
-func _ImageBuilder_ResolveBaseImage_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+func _ImageBuilder_ResolveBaseImage_Handler(srv any, ctx context.Context, dec func(any) error, interceptor grpc.UnaryServerInterceptor) (any, error) {
 	in := new(ResolveBaseImageRequest)
 	if err := dec(in); err != nil {
 		return nil, err
@@ -200,13 +200,13 @@ func _ImageBuilder_ResolveBaseImage_Handler(srv interface{}, ctx context.Context
 		Server:     srv,
 		FullMethod: "/builder.ImageBuilder/ResolveBaseImage",
 	}
-	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+	handler := func(ctx context.Context, req any) (any, error) {
 		return srv.(ImageBuilderServer).ResolveBaseImage(ctx, req.(*ResolveBaseImageRequest))
 	}
 	return interceptor(ctx, in, info, handler)
 }
 
-func _ImageBuilder_ResolveWorkspaceImage_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+func _ImageBuilder_ResolveWorkspaceImage_Handler(srv any, ctx context.Context, dec func(any) error, interceptor grpc.UnaryServerInterceptor) (any, error) {
 	in := new(ResolveWorkspaceImageRequest)
 	if err := dec(in); err != nil {
 		return nil, err
@@ -218,13 +218,13 @@ func _ImageBuilder_ResolveWorkspaceImage_Handler(srv interface{}, ctx context.Co
 		Server:     srv,
 		FullMethod: "/builder.ImageBuilder/ResolveWorkspaceImage",
 	}
-	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+	handler := func(ctx context.Context, req any) (any, error) {
 		return srv.(ImageBuilderServer).ResolveWorkspaceImage(ctx, req.(*ResolveWorkspaceImageRequest))
 	}
 	return interceptor(ctx, in, info, handler)
 }
 
-func _ImageBuilder_Build_Handler(srv interface{}, stream grpc.ServerStream) error {
+func _ImageBuilder_Build_Handler(srv any, stream grpc.ServerStream) error {
 	m := new(BuildRequest)
 	if err := stream.RecvMsg(m); err != nil {
 		return err
@@ -245,7 +245,7 @@ func (x *imageBuilderBuildServer) Send(m *BuildResponse) error {
 	return x.ServerStream.SendMsg(m)
 }
 
-func _ImageBuilder_Logs_Handler(srv interface{}, stream grpc.ServerStream) error {
+func _ImageBuilder_Logs_Handler(srv any, stream grpc.ServerStream) error {
 	m := new(LogsRequest)
 	if err := stream.RecvMsg(m); err != nil {
 		return err
@@ -266,7 +266,7 @@ func (x *imageBuilderLogsServer) Send(m *LogsResponse) error {
 	return x.ServerStream.SendMsg(m)
 }
 
-func _ImageBuilder_ListBuilds_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+func _ImageBuilder_ListBuilds_Handler(srv any, ctx context.Context, dec func(any) error, interceptor grpc.UnaryServerInterceptor) (any, error) {
 	in := new(ListBuildsRequest)
 	if err := dec(in); err != nil {
 		return nil, err
@@ -278,7 +278,7 @@ func _ImageBuilder_ListBuilds_Handler(srv interface{}, ctx context.Context, dec 
 		Server:     srv,
 		FullMethod: "/builder.ImageBuilder/ListBuilds",
 	}
-	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+	handler := func(ctx context.Context, req any) (any, error) {
 		return srv.(ImageBuilderServer).ListBuilds(ctx, req.(*ListBuildsRequest))
 	}
 	return interceptor(ctx, in, info, handler)

--- a/components/image-builder-api/go/mock/mock.go
+++ b/components/image-builder-api/go/mock/mock.go
@@ -44,7 +44,7 @@ func (m *MockImageBuilderClient) EXPECT() *MockImageBuilderClientMockRecorder {
 // Build mocks base method.
 func (m *MockImageBuilderClient) Build(arg0 context.Context, arg1 *api.BuildRequest, arg2 ...grpc.CallOption) (api.ImageBuilder_BuildClient, error) {
 	m.ctrl.T.Helper()
-	varargs := []interface{}{arg0, arg1}
+	varargs := []any{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
 	}
@@ -55,16 +55,16 @@ func (m *MockImageBuilderClient) Build(arg0 context.Context, arg1 *api.BuildRequ
 }
 
 // Build indicates an expected call of Build.
-func (mr *MockImageBuilderClientMockRecorder) Build(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+func (mr *MockImageBuilderClientMockRecorder) Build(arg0, arg1 any, arg2 ...any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	varargs := append([]interface{}{arg0, arg1}, arg2...)
+	varargs := append([]any{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Build", reflect.TypeOf((*MockImageBuilderClient)(nil).Build), varargs...)
 }
 
 // ListBuilds mocks base method.
 func (m *MockImageBuilderClient) ListBuilds(arg0 context.Context, arg1 *api.ListBuildsRequest, arg2 ...grpc.CallOption) (*api.ListBuildsResponse, error) {
 	m.ctrl.T.Helper()
-	varargs := []interface{}{arg0, arg1}
+	varargs := []any{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
 	}
@@ -75,16 +75,16 @@ func (m *MockImageBuilderClient) ListBuilds(arg0 context.Context, arg1 *api.List
 }
 
 // ListBuilds indicates an expected call of ListBuilds.
-func (mr *MockImageBuilderClientMockRecorder) ListBuilds(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+func (mr *MockImageBuilderClientMockRecorder) ListBuilds(arg0, arg1 any, arg2 ...any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	varargs := append([]interface{}{arg0, arg1}, arg2...)
+	varargs := append([]any{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListBuilds", reflect.TypeOf((*MockImageBuilderClient)(nil).ListBuilds), varargs...)
 }
 
 // Logs mocks base method.
 func (m *MockImageBuilderClient) Logs(arg0 context.Context, arg1 *api.LogsRequest, arg2 ...grpc.CallOption) (api.ImageBuilder_LogsClient, error) {
 	m.ctrl.T.Helper()
-	varargs := []interface{}{arg0, arg1}
+	varargs := []any{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
 	}
@@ -95,16 +95,16 @@ func (m *MockImageBuilderClient) Logs(arg0 context.Context, arg1 *api.LogsReques
 }
 
 // Logs indicates an expected call of Logs.
-func (mr *MockImageBuilderClientMockRecorder) Logs(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+func (mr *MockImageBuilderClientMockRecorder) Logs(arg0, arg1 any, arg2 ...any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	varargs := append([]interface{}{arg0, arg1}, arg2...)
+	varargs := append([]any{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Logs", reflect.TypeOf((*MockImageBuilderClient)(nil).Logs), varargs...)
 }
 
 // ResolveBaseImage mocks base method.
 func (m *MockImageBuilderClient) ResolveBaseImage(arg0 context.Context, arg1 *api.ResolveBaseImageRequest, arg2 ...grpc.CallOption) (*api.ResolveBaseImageResponse, error) {
 	m.ctrl.T.Helper()
-	varargs := []interface{}{arg0, arg1}
+	varargs := []any{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
 	}
@@ -115,16 +115,16 @@ func (m *MockImageBuilderClient) ResolveBaseImage(arg0 context.Context, arg1 *ap
 }
 
 // ResolveBaseImage indicates an expected call of ResolveBaseImage.
-func (mr *MockImageBuilderClientMockRecorder) ResolveBaseImage(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+func (mr *MockImageBuilderClientMockRecorder) ResolveBaseImage(arg0, arg1 any, arg2 ...any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	varargs := append([]interface{}{arg0, arg1}, arg2...)
+	varargs := append([]any{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ResolveBaseImage", reflect.TypeOf((*MockImageBuilderClient)(nil).ResolveBaseImage), varargs...)
 }
 
 // ResolveWorkspaceImage mocks base method.
 func (m *MockImageBuilderClient) ResolveWorkspaceImage(arg0 context.Context, arg1 *api.ResolveWorkspaceImageRequest, arg2 ...grpc.CallOption) (*api.ResolveWorkspaceImageResponse, error) {
 	m.ctrl.T.Helper()
-	varargs := []interface{}{arg0, arg1}
+	varargs := []any{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
 	}
@@ -135,9 +135,9 @@ func (m *MockImageBuilderClient) ResolveWorkspaceImage(arg0 context.Context, arg
 }
 
 // ResolveWorkspaceImage indicates an expected call of ResolveWorkspaceImage.
-func (mr *MockImageBuilderClientMockRecorder) ResolveWorkspaceImage(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+func (mr *MockImageBuilderClientMockRecorder) ResolveWorkspaceImage(arg0, arg1 any, arg2 ...any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	varargs := append([]interface{}{arg0, arg1}, arg2...)
+	varargs := append([]any{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ResolveWorkspaceImage", reflect.TypeOf((*MockImageBuilderClient)(nil).ResolveWorkspaceImage), varargs...)
 }
 
@@ -223,7 +223,7 @@ func (mr *MockImageBuilder_BuildClientMockRecorder) Recv() *gomock.Call {
 }
 
 // RecvMsg mocks base method.
-func (m *MockImageBuilder_BuildClient) RecvMsg(arg0 interface{}) error {
+func (m *MockImageBuilder_BuildClient) RecvMsg(arg0 any) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "RecvMsg", arg0)
 	ret0, _ := ret[0].(error)
@@ -231,13 +231,13 @@ func (m *MockImageBuilder_BuildClient) RecvMsg(arg0 interface{}) error {
 }
 
 // RecvMsg indicates an expected call of RecvMsg.
-func (mr *MockImageBuilder_BuildClientMockRecorder) RecvMsg(arg0 interface{}) *gomock.Call {
+func (mr *MockImageBuilder_BuildClientMockRecorder) RecvMsg(arg0 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RecvMsg", reflect.TypeOf((*MockImageBuilder_BuildClient)(nil).RecvMsg), arg0)
 }
 
 // SendMsg mocks base method.
-func (m *MockImageBuilder_BuildClient) SendMsg(arg0 interface{}) error {
+func (m *MockImageBuilder_BuildClient) SendMsg(arg0 any) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SendMsg", arg0)
 	ret0, _ := ret[0].(error)
@@ -245,7 +245,7 @@ func (m *MockImageBuilder_BuildClient) SendMsg(arg0 interface{}) error {
 }
 
 // SendMsg indicates an expected call of SendMsg.
-func (mr *MockImageBuilder_BuildClientMockRecorder) SendMsg(arg0 interface{}) *gomock.Call {
+func (mr *MockImageBuilder_BuildClientMockRecorder) SendMsg(arg0 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SendMsg", reflect.TypeOf((*MockImageBuilder_BuildClient)(nil).SendMsg), arg0)
 }
@@ -346,7 +346,7 @@ func (mr *MockImageBuilder_LogsClientMockRecorder) Recv() *gomock.Call {
 }
 
 // RecvMsg mocks base method.
-func (m *MockImageBuilder_LogsClient) RecvMsg(arg0 interface{}) error {
+func (m *MockImageBuilder_LogsClient) RecvMsg(arg0 any) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "RecvMsg", arg0)
 	ret0, _ := ret[0].(error)
@@ -354,13 +354,13 @@ func (m *MockImageBuilder_LogsClient) RecvMsg(arg0 interface{}) error {
 }
 
 // RecvMsg indicates an expected call of RecvMsg.
-func (mr *MockImageBuilder_LogsClientMockRecorder) RecvMsg(arg0 interface{}) *gomock.Call {
+func (mr *MockImageBuilder_LogsClientMockRecorder) RecvMsg(arg0 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RecvMsg", reflect.TypeOf((*MockImageBuilder_LogsClient)(nil).RecvMsg), arg0)
 }
 
 // SendMsg mocks base method.
-func (m *MockImageBuilder_LogsClient) SendMsg(arg0 interface{}) error {
+func (m *MockImageBuilder_LogsClient) SendMsg(arg0 any) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SendMsg", arg0)
 	ret0, _ := ret[0].(error)
@@ -368,7 +368,7 @@ func (m *MockImageBuilder_LogsClient) SendMsg(arg0 interface{}) error {
 }
 
 // SendMsg indicates an expected call of SendMsg.
-func (mr *MockImageBuilder_LogsClientMockRecorder) SendMsg(arg0 interface{}) *gomock.Call {
+func (mr *MockImageBuilder_LogsClientMockRecorder) SendMsg(arg0 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SendMsg", reflect.TypeOf((*MockImageBuilder_LogsClient)(nil).SendMsg), arg0)
 }
@@ -419,7 +419,7 @@ func (m *MockImageBuilderServer) Build(arg0 *api.BuildRequest, arg1 api.ImageBui
 }
 
 // Build indicates an expected call of Build.
-func (mr *MockImageBuilderServerMockRecorder) Build(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockImageBuilderServerMockRecorder) Build(arg0, arg1 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Build", reflect.TypeOf((*MockImageBuilderServer)(nil).Build), arg0, arg1)
 }
@@ -434,7 +434,7 @@ func (m *MockImageBuilderServer) ListBuilds(arg0 context.Context, arg1 *api.List
 }
 
 // ListBuilds indicates an expected call of ListBuilds.
-func (mr *MockImageBuilderServerMockRecorder) ListBuilds(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockImageBuilderServerMockRecorder) ListBuilds(arg0, arg1 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListBuilds", reflect.TypeOf((*MockImageBuilderServer)(nil).ListBuilds), arg0, arg1)
 }
@@ -448,7 +448,7 @@ func (m *MockImageBuilderServer) Logs(arg0 *api.LogsRequest, arg1 api.ImageBuild
 }
 
 // Logs indicates an expected call of Logs.
-func (mr *MockImageBuilderServerMockRecorder) Logs(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockImageBuilderServerMockRecorder) Logs(arg0, arg1 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Logs", reflect.TypeOf((*MockImageBuilderServer)(nil).Logs), arg0, arg1)
 }
@@ -463,7 +463,7 @@ func (m *MockImageBuilderServer) ResolveBaseImage(arg0 context.Context, arg1 *ap
 }
 
 // ResolveBaseImage indicates an expected call of ResolveBaseImage.
-func (mr *MockImageBuilderServerMockRecorder) ResolveBaseImage(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockImageBuilderServerMockRecorder) ResolveBaseImage(arg0, arg1 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ResolveBaseImage", reflect.TypeOf((*MockImageBuilderServer)(nil).ResolveBaseImage), arg0, arg1)
 }
@@ -478,7 +478,7 @@ func (m *MockImageBuilderServer) ResolveWorkspaceImage(arg0 context.Context, arg
 }
 
 // ResolveWorkspaceImage indicates an expected call of ResolveWorkspaceImage.
-func (mr *MockImageBuilderServerMockRecorder) ResolveWorkspaceImage(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockImageBuilderServerMockRecorder) ResolveWorkspaceImage(arg0, arg1 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ResolveWorkspaceImage", reflect.TypeOf((*MockImageBuilderServer)(nil).ResolveWorkspaceImage), arg0, arg1)
 }
@@ -533,7 +533,7 @@ func (mr *MockImageBuilder_BuildServerMockRecorder) Context() *gomock.Call {
 }
 
 // RecvMsg mocks base method.
-func (m *MockImageBuilder_BuildServer) RecvMsg(arg0 interface{}) error {
+func (m *MockImageBuilder_BuildServer) RecvMsg(arg0 any) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "RecvMsg", arg0)
 	ret0, _ := ret[0].(error)
@@ -541,7 +541,7 @@ func (m *MockImageBuilder_BuildServer) RecvMsg(arg0 interface{}) error {
 }
 
 // RecvMsg indicates an expected call of RecvMsg.
-func (mr *MockImageBuilder_BuildServerMockRecorder) RecvMsg(arg0 interface{}) *gomock.Call {
+func (mr *MockImageBuilder_BuildServerMockRecorder) RecvMsg(arg0 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RecvMsg", reflect.TypeOf((*MockImageBuilder_BuildServer)(nil).RecvMsg), arg0)
 }
@@ -555,7 +555,7 @@ func (m *MockImageBuilder_BuildServer) Send(arg0 *api.BuildResponse) error {
 }
 
 // Send indicates an expected call of Send.
-func (mr *MockImageBuilder_BuildServerMockRecorder) Send(arg0 interface{}) *gomock.Call {
+func (mr *MockImageBuilder_BuildServerMockRecorder) Send(arg0 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Send", reflect.TypeOf((*MockImageBuilder_BuildServer)(nil).Send), arg0)
 }
@@ -569,13 +569,13 @@ func (m *MockImageBuilder_BuildServer) SendHeader(arg0 metadata.MD) error {
 }
 
 // SendHeader indicates an expected call of SendHeader.
-func (mr *MockImageBuilder_BuildServerMockRecorder) SendHeader(arg0 interface{}) *gomock.Call {
+func (mr *MockImageBuilder_BuildServerMockRecorder) SendHeader(arg0 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SendHeader", reflect.TypeOf((*MockImageBuilder_BuildServer)(nil).SendHeader), arg0)
 }
 
 // SendMsg mocks base method.
-func (m *MockImageBuilder_BuildServer) SendMsg(arg0 interface{}) error {
+func (m *MockImageBuilder_BuildServer) SendMsg(arg0 any) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SendMsg", arg0)
 	ret0, _ := ret[0].(error)
@@ -583,7 +583,7 @@ func (m *MockImageBuilder_BuildServer) SendMsg(arg0 interface{}) error {
 }
 
 // SendMsg indicates an expected call of SendMsg.
-func (mr *MockImageBuilder_BuildServerMockRecorder) SendMsg(arg0 interface{}) *gomock.Call {
+func (mr *MockImageBuilder_BuildServerMockRecorder) SendMsg(arg0 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SendMsg", reflect.TypeOf((*MockImageBuilder_BuildServer)(nil).SendMsg), arg0)
 }
@@ -597,7 +597,7 @@ func (m *MockImageBuilder_BuildServer) SetHeader(arg0 metadata.MD) error {
 }
 
 // SetHeader indicates an expected call of SetHeader.
-func (mr *MockImageBuilder_BuildServerMockRecorder) SetHeader(arg0 interface{}) *gomock.Call {
+func (mr *MockImageBuilder_BuildServerMockRecorder) SetHeader(arg0 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetHeader", reflect.TypeOf((*MockImageBuilder_BuildServer)(nil).SetHeader), arg0)
 }
@@ -609,7 +609,7 @@ func (m *MockImageBuilder_BuildServer) SetTrailer(arg0 metadata.MD) {
 }
 
 // SetTrailer indicates an expected call of SetTrailer.
-func (mr *MockImageBuilder_BuildServerMockRecorder) SetTrailer(arg0 interface{}) *gomock.Call {
+func (mr *MockImageBuilder_BuildServerMockRecorder) SetTrailer(arg0 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetTrailer", reflect.TypeOf((*MockImageBuilder_BuildServer)(nil).SetTrailer), arg0)
 }
@@ -652,7 +652,7 @@ func (mr *MockImageBuilder_LogsServerMockRecorder) Context() *gomock.Call {
 }
 
 // RecvMsg mocks base method.
-func (m *MockImageBuilder_LogsServer) RecvMsg(arg0 interface{}) error {
+func (m *MockImageBuilder_LogsServer) RecvMsg(arg0 any) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "RecvMsg", arg0)
 	ret0, _ := ret[0].(error)
@@ -660,7 +660,7 @@ func (m *MockImageBuilder_LogsServer) RecvMsg(arg0 interface{}) error {
 }
 
 // RecvMsg indicates an expected call of RecvMsg.
-func (mr *MockImageBuilder_LogsServerMockRecorder) RecvMsg(arg0 interface{}) *gomock.Call {
+func (mr *MockImageBuilder_LogsServerMockRecorder) RecvMsg(arg0 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RecvMsg", reflect.TypeOf((*MockImageBuilder_LogsServer)(nil).RecvMsg), arg0)
 }
@@ -674,7 +674,7 @@ func (m *MockImageBuilder_LogsServer) Send(arg0 *api.LogsResponse) error {
 }
 
 // Send indicates an expected call of Send.
-func (mr *MockImageBuilder_LogsServerMockRecorder) Send(arg0 interface{}) *gomock.Call {
+func (mr *MockImageBuilder_LogsServerMockRecorder) Send(arg0 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Send", reflect.TypeOf((*MockImageBuilder_LogsServer)(nil).Send), arg0)
 }
@@ -688,13 +688,13 @@ func (m *MockImageBuilder_LogsServer) SendHeader(arg0 metadata.MD) error {
 }
 
 // SendHeader indicates an expected call of SendHeader.
-func (mr *MockImageBuilder_LogsServerMockRecorder) SendHeader(arg0 interface{}) *gomock.Call {
+func (mr *MockImageBuilder_LogsServerMockRecorder) SendHeader(arg0 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SendHeader", reflect.TypeOf((*MockImageBuilder_LogsServer)(nil).SendHeader), arg0)
 }
 
 // SendMsg mocks base method.
-func (m *MockImageBuilder_LogsServer) SendMsg(arg0 interface{}) error {
+func (m *MockImageBuilder_LogsServer) SendMsg(arg0 any) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SendMsg", arg0)
 	ret0, _ := ret[0].(error)
@@ -702,7 +702,7 @@ func (m *MockImageBuilder_LogsServer) SendMsg(arg0 interface{}) error {
 }
 
 // SendMsg indicates an expected call of SendMsg.
-func (mr *MockImageBuilder_LogsServerMockRecorder) SendMsg(arg0 interface{}) *gomock.Call {
+func (mr *MockImageBuilder_LogsServerMockRecorder) SendMsg(arg0 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SendMsg", reflect.TypeOf((*MockImageBuilder_LogsServer)(nil).SendMsg), arg0)
 }
@@ -716,7 +716,7 @@ func (m *MockImageBuilder_LogsServer) SetHeader(arg0 metadata.MD) error {
 }
 
 // SetHeader indicates an expected call of SetHeader.
-func (mr *MockImageBuilder_LogsServerMockRecorder) SetHeader(arg0 interface{}) *gomock.Call {
+func (mr *MockImageBuilder_LogsServerMockRecorder) SetHeader(arg0 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetHeader", reflect.TypeOf((*MockImageBuilder_LogsServer)(nil).SetHeader), arg0)
 }
@@ -728,7 +728,7 @@ func (m *MockImageBuilder_LogsServer) SetTrailer(arg0 metadata.MD) {
 }
 
 // SetTrailer indicates an expected call of SetTrailer.
-func (mr *MockImageBuilder_LogsServerMockRecorder) SetTrailer(arg0 interface{}) *gomock.Call {
+func (mr *MockImageBuilder_LogsServerMockRecorder) SetTrailer(arg0 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetTrailer", reflect.TypeOf((*MockImageBuilder_LogsServer)(nil).SetTrailer), arg0)
 }

--- a/components/image-builder-mk3/pkg/orchestrator/orchestrator.go
+++ b/components/image-builder-mk3/pkg/orchestrator/orchestrator.go
@@ -674,7 +674,7 @@ func (c *parentCantCancelContext) Err() error {
 	return err
 }
 
-func (c *parentCantCancelContext) Value(key interface{}) interface{} {
+func (c *parentCantCancelContext) Value(key any) any {
 	return c.Delegate.Value(key)
 }
 

--- a/components/image-builder-mk3/pkg/orchestrator/orchestrator_test.go
+++ b/components/image-builder-mk3/pkg/orchestrator/orchestrator_test.go
@@ -48,7 +48,7 @@ func TestBuild(t *testing.T) {
 			}
 			builder.RefResolver = resolver
 			wsman.EXPECT().StartWorkspace(gomock.Any(), gomock.Any(), gomock.Any()).
-				DoAndReturn(func(ctx context.Context, req *wsmanapi.StartWorkspaceRequest, _ ...interface{}) (*wsmanapi.StartWorkspaceResponse, error) {
+				DoAndReturn(func(ctx context.Context, req *wsmanapi.StartWorkspaceRequest, _ ...any) (*wsmanapi.StartWorkspaceResponse, error) {
 					close(pushUpdate)
 					t.Log("StartWorkspace called")
 

--- a/components/image-builder-mk3/pkg/resolve/resolve_mock_test.go
+++ b/components/image-builder-mk3/pkg/resolve/resolve_mock_test.go
@@ -51,7 +51,7 @@ func (m *MockResolver) Fetcher(arg0 context.Context, arg1 string) (remotes.Fetch
 }
 
 // Fetcher indicates an expected call of Fetcher.
-func (mr *MockResolverMockRecorder) Fetcher(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockResolverMockRecorder) Fetcher(arg0, arg1 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Fetcher", reflect.TypeOf((*MockResolver)(nil).Fetcher), arg0, arg1)
 }
@@ -66,7 +66,7 @@ func (m *MockResolver) Pusher(arg0 context.Context, arg1 string) (remotes.Pusher
 }
 
 // Pusher indicates an expected call of Pusher.
-func (mr *MockResolverMockRecorder) Pusher(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockResolverMockRecorder) Pusher(arg0, arg1 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Pusher", reflect.TypeOf((*MockResolver)(nil).Pusher), arg0, arg1)
 }
@@ -82,7 +82,7 @@ func (m *MockResolver) Resolve(arg0 context.Context, arg1 string) (string, v1.De
 }
 
 // Resolve indicates an expected call of Resolve.
-func (mr *MockResolverMockRecorder) Resolve(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockResolverMockRecorder) Resolve(arg0, arg1 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Resolve", reflect.TypeOf((*MockResolver)(nil).Resolve), arg0, arg1)
 }
@@ -120,7 +120,7 @@ func (m *MockFetcher) Fetch(arg0 context.Context, arg1 v1.Descriptor) (io.ReadCl
 }
 
 // Fetch indicates an expected call of Fetch.
-func (mr *MockFetcherMockRecorder) Fetch(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockFetcherMockRecorder) Fetch(arg0, arg1 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Fetch", reflect.TypeOf((*MockFetcher)(nil).Fetch), arg0, arg1)
 }

--- a/components/licensor/ee/pkg/licensor/replicated.go
+++ b/components/licensor/ee/pkg/licensor/replicated.go
@@ -17,10 +17,10 @@ const (
 )
 
 type replicatedFields struct {
-	Field string      `json:"field"`
-	Title string      `json:"title"`
-	Type  string      `json:"type"`
-	Value interface{} `json:"value"` // This is of type "fieldType"
+	Field string `json:"field"`
+	Title string `json:"title"`
+	Type  string `json:"type"`
+	Value any    `json:"value"` // This is of type "fieldType"
 }
 
 // replicatedLicensePayload exists to convert the JSON structure to a LicensePayload

--- a/components/local-app-api/go/localapp.pb.go
+++ b/components/local-app-api/go/localapp.pb.go
@@ -474,7 +474,7 @@ func file_localapp_proto_rawDescGZIP() []byte {
 }
 
 var file_localapp_proto_msgTypes = make([]protoimpl.MessageInfo, 7)
-var file_localapp_proto_goTypes = []interface{}{
+var file_localapp_proto_goTypes = []any{
 	(*TunnelStatusRequest)(nil),          // 0: localapp.TunnelStatusRequest
 	(*TunnelStatusResponse)(nil),         // 1: localapp.TunnelStatusResponse
 	(*TunnelStatus)(nil),                 // 2: localapp.TunnelStatus
@@ -506,7 +506,7 @@ func file_localapp_proto_init() {
 		return
 	}
 	if !protoimpl.UnsafeEnabled {
-		file_localapp_proto_msgTypes[0].Exporter = func(v interface{}, i int) interface{} {
+		file_localapp_proto_msgTypes[0].Exporter = func(v any, i int) any {
 			switch v := v.(*TunnelStatusRequest); i {
 			case 0:
 				return &v.state
@@ -518,7 +518,7 @@ func file_localapp_proto_init() {
 				return nil
 			}
 		}
-		file_localapp_proto_msgTypes[1].Exporter = func(v interface{}, i int) interface{} {
+		file_localapp_proto_msgTypes[1].Exporter = func(v any, i int) any {
 			switch v := v.(*TunnelStatusResponse); i {
 			case 0:
 				return &v.state
@@ -530,7 +530,7 @@ func file_localapp_proto_init() {
 				return nil
 			}
 		}
-		file_localapp_proto_msgTypes[2].Exporter = func(v interface{}, i int) interface{} {
+		file_localapp_proto_msgTypes[2].Exporter = func(v any, i int) any {
 			switch v := v.(*TunnelStatus); i {
 			case 0:
 				return &v.state
@@ -542,7 +542,7 @@ func file_localapp_proto_init() {
 				return nil
 			}
 		}
-		file_localapp_proto_msgTypes[3].Exporter = func(v interface{}, i int) interface{} {
+		file_localapp_proto_msgTypes[3].Exporter = func(v any, i int) any {
 			switch v := v.(*AutoTunnelRequest); i {
 			case 0:
 				return &v.state
@@ -554,7 +554,7 @@ func file_localapp_proto_init() {
 				return nil
 			}
 		}
-		file_localapp_proto_msgTypes[4].Exporter = func(v interface{}, i int) interface{} {
+		file_localapp_proto_msgTypes[4].Exporter = func(v any, i int) any {
 			switch v := v.(*AutoTunnelResponse); i {
 			case 0:
 				return &v.state
@@ -566,7 +566,7 @@ func file_localapp_proto_init() {
 				return nil
 			}
 		}
-		file_localapp_proto_msgTypes[5].Exporter = func(v interface{}, i int) interface{} {
+		file_localapp_proto_msgTypes[5].Exporter = func(v any, i int) any {
 			switch v := v.(*ResolveSSHConnectionRequest); i {
 			case 0:
 				return &v.state
@@ -578,7 +578,7 @@ func file_localapp_proto_init() {
 				return nil
 			}
 		}
-		file_localapp_proto_msgTypes[6].Exporter = func(v interface{}, i int) interface{} {
+		file_localapp_proto_msgTypes[6].Exporter = func(v any, i int) any {
 			switch v := v.(*ResolveSSHConnectionResponse); i {
 			case 0:
 				return &v.state

--- a/components/local-app-api/go/localapp_grpc.pb.go
+++ b/components/local-app-api/go/localapp_grpc.pb.go
@@ -125,7 +125,7 @@ func RegisterLocalAppServer(s grpc.ServiceRegistrar, srv LocalAppServer) {
 	s.RegisterService(&LocalApp_ServiceDesc, srv)
 }
 
-func _LocalApp_TunnelStatus_Handler(srv interface{}, stream grpc.ServerStream) error {
+func _LocalApp_TunnelStatus_Handler(srv any, stream grpc.ServerStream) error {
 	m := new(TunnelStatusRequest)
 	if err := stream.RecvMsg(m); err != nil {
 		return err
@@ -146,7 +146,7 @@ func (x *localAppTunnelStatusServer) Send(m *TunnelStatusResponse) error {
 	return x.ServerStream.SendMsg(m)
 }
 
-func _LocalApp_AutoTunnel_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+func _LocalApp_AutoTunnel_Handler(srv any, ctx context.Context, dec func(any) error, interceptor grpc.UnaryServerInterceptor) (any, error) {
 	in := new(AutoTunnelRequest)
 	if err := dec(in); err != nil {
 		return nil, err
@@ -158,13 +158,13 @@ func _LocalApp_AutoTunnel_Handler(srv interface{}, ctx context.Context, dec func
 		Server:     srv,
 		FullMethod: "/localapp.LocalApp/AutoTunnel",
 	}
-	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+	handler := func(ctx context.Context, req any) (any, error) {
 		return srv.(LocalAppServer).AutoTunnel(ctx, req.(*AutoTunnelRequest))
 	}
 	return interceptor(ctx, in, info, handler)
 }
 
-func _LocalApp_ResolveSSHConnection_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+func _LocalApp_ResolveSSHConnection_Handler(srv any, ctx context.Context, dec func(any) error, interceptor grpc.UnaryServerInterceptor) (any, error) {
 	in := new(ResolveSSHConnectionRequest)
 	if err := dec(in); err != nil {
 		return nil, err
@@ -176,7 +176,7 @@ func _LocalApp_ResolveSSHConnection_Handler(srv interface{}, ctx context.Context
 		Server:     srv,
 		FullMethod: "/localapp.LocalApp/ResolveSSHConnection",
 	}
-	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+	handler := func(ctx context.Context, req any) (any, error) {
 		return srv.(LocalAppServer).ResolveSSHConnection(ctx, req.(*ResolveSSHConnectionRequest))
 	}
 	return interceptor(ctx, in, info, handler)

--- a/components/proxy/plugins/jsonselect/plugin.go
+++ b/components/proxy/plugins/jsonselect/plugin.go
@@ -54,7 +54,7 @@ func (e *JSONSelectEncoder) Provision(ctx caddy.Context) error {
 	e.setters = [][]string{}
 	e.getters = [][]string{}
 	r := caddy.NewReplacer()
-	r.Map(func(sel string) (interface{}, bool) {
+	r.Map(func(sel string) (any, bool) {
 		var set, get string
 
 		parts := strings.Split(sel, ":")

--- a/components/proxy/plugins/logif/lang/lang.go
+++ b/components/proxy/plugins/logif/lang/lang.go
@@ -18,24 +18,24 @@ import (
 
 var Lang = gval.NewLanguage(
 	// Logic
-	gval.InfixShortCircuit("&&", func(lhs interface{}) (interface{}, bool) { return false, lhs == false }),
-	gval.InfixShortCircuit("||", func(lhs interface{}) (interface{}, bool) { return true, lhs == true }),
+	gval.InfixShortCircuit("&&", func(lhs any) (any, bool) { return false, lhs == false }),
+	gval.InfixShortCircuit("||", func(lhs any) (any, bool) { return true, lhs == true }),
 
-	gval.InfixBoolOperator("&&", func(lhs, rhs bool) (interface{}, error) { return lhs && rhs, nil }),
-	gval.InfixBoolOperator("||", func(lhs, rhs bool) (interface{}, error) { return lhs || rhs, nil }),
+	gval.InfixBoolOperator("&&", func(lhs, rhs bool) (any, error) { return lhs && rhs, nil }),
+	gval.InfixBoolOperator("||", func(lhs, rhs bool) (any, error) { return lhs || rhs, nil }),
 
-	gval.InfixBoolOperator("==", func(lhs, rhs bool) (interface{}, error) { return lhs == rhs, nil }),
-	gval.InfixBoolOperator("!=", func(lhs, rhs bool) (interface{}, error) { return lhs != rhs, nil }),
+	gval.InfixBoolOperator("==", func(lhs, rhs bool) (any, error) { return lhs == rhs, nil }),
+	gval.InfixBoolOperator("!=", func(lhs, rhs bool) (any, error) { return lhs != rhs, nil }),
 
 	// Arithmetic
 
-	gval.InfixNumberOperator("==", func(lhs, rhs float64) (interface{}, error) { return lhs == rhs, nil }),
-	gval.InfixNumberOperator("!=", func(lhs, rhs float64) (interface{}, error) { return lhs != rhs, nil }),
+	gval.InfixNumberOperator("==", func(lhs, rhs float64) (any, error) { return lhs == rhs, nil }),
+	gval.InfixNumberOperator("!=", func(lhs, rhs float64) (any, error) { return lhs != rhs, nil }),
 
-	gval.InfixNumberOperator("<", func(lhs, rhs float64) (interface{}, error) { return lhs < rhs, nil }),
-	gval.InfixNumberOperator("<=", func(lhs, rhs float64) (interface{}, error) { return lhs <= rhs, nil }),
-	gval.InfixNumberOperator(">", func(lhs, rhs float64) (interface{}, error) { return lhs > rhs, nil }),
-	gval.InfixNumberOperator(">=", func(lhs, rhs float64) (interface{}, error) { return lhs >= rhs, nil }),
+	gval.InfixNumberOperator("<", func(lhs, rhs float64) (any, error) { return lhs < rhs, nil }),
+	gval.InfixNumberOperator("<=", func(lhs, rhs float64) (any, error) { return lhs <= rhs, nil }),
+	gval.InfixNumberOperator(">", func(lhs, rhs float64) (any, error) { return lhs > rhs, nil }),
+	gval.InfixNumberOperator(">=", func(lhs, rhs float64) (any, error) { return lhs >= rhs, nil }),
 
 	// Text
 
@@ -43,8 +43,8 @@ var Lang = gval.NewLanguage(
 
 	// Base
 
-	gval.InfixOperator("==", func(lhs, rhs interface{}) (interface{}, error) { return reflect.DeepEqual(lhs, rhs), nil }),
-	gval.InfixOperator("!=", func(lhs, rhs interface{}) (interface{}, error) { return !reflect.DeepEqual(lhs, rhs), nil }),
+	gval.InfixOperator("==", func(lhs, rhs any) (any, error) { return reflect.DeepEqual(lhs, rhs), nil }),
+	gval.InfixOperator("!=", func(lhs, rhs any) (any, error) { return !reflect.DeepEqual(lhs, rhs), nil }),
 
 	gval.PrefixExtension(scanner.Int, parseNumber),
 	gval.PrefixExtension(scanner.Float, parseNumber),
@@ -76,7 +76,7 @@ func Compile(expression string) (gval.Evaluable, error) {
 	return Lang.NewEvaluable(expression)
 }
 
-func Execute(eval gval.Evaluable, data map[string]interface{}) (interface{}, error) {
+func Execute(eval gval.Evaluable, data map[string]any) (any, error) {
 	return eval(context.Background(), data)
 }
 
@@ -98,7 +98,7 @@ func parseNumber(c context.Context, p *gval.Parser) (gval.Evaluable, error) {
 
 func regEx(a, b gval.Evaluable) (gval.Evaluable, error) {
 	if !b.IsConst() {
-		return func(c context.Context, o interface{}) (interface{}, error) {
+		return func(c context.Context, o any) (any, error) {
 			a, err := a.EvalString(c, o)
 			if err != nil {
 				return nil, err
@@ -119,7 +119,7 @@ func regEx(a, b gval.Evaluable) (gval.Evaluable, error) {
 	if err != nil {
 		return nil, err
 	}
-	return func(c context.Context, v interface{}) (interface{}, error) {
+	return func(c context.Context, v any) (any, error) {
 		s, err := a.EvalString(c, v)
 		if err != nil {
 			return nil, err

--- a/components/proxy/plugins/logif/plugin.go
+++ b/components/proxy/plugins/logif/plugin.go
@@ -91,7 +91,7 @@ func (ce ConditionalEncoder) EncodeEntry(e zapcore.Entry, fields []zapcore.Field
 	}
 
 	// Extract values
-	values := make(map[string]interface{})
+	values := make(map[string]any)
 	for _, key := range lang.Fields {
 		path := strings.Split(key, ">")
 		val, typ, _, err := jsonparser.Get(data, path...)

--- a/components/proxy/plugins/sshtunnel/ssh-tunnel.go
+++ b/components/proxy/plugins/sshtunnel/ssh-tunnel.go
@@ -24,19 +24,19 @@ func init() {
 	caddyconfig.RegisterAdapter("inject-ssh-tunnel", InjectSSHTunnelAdaper{})
 }
 
-func (a InjectSSHTunnelAdaper) Adapt(body []byte, options map[string]interface{}) (result []byte, warnings []caddyconfig.Warning, err error) {
+func (a InjectSSHTunnelAdaper) Adapt(body []byte, options map[string]any) (result []byte, warnings []caddyconfig.Warning, err error) {
 	c := caddyfile.Adapter{ServerType: httpcaddyfile.ServerType{}}
 	result, warnings, err = c.Adapt(body, options)
 	if err != nil {
 		return
 	}
-	var r map[string]interface{}
+	var r map[string]any
 	err = json.Unmarshal(result, &r)
 	if err != nil {
 		return
 	}
-	if apps, ok := r["apps"].(map[string]interface{}); ok {
-		apps["ssh-tunnel"] = make(map[string]interface{})
+	if apps, ok := r["apps"].(map[string]any); ok {
+		apps["ssh-tunnel"] = make(map[string]any)
 		result, err = json.Marshal(r)
 	}
 	return

--- a/components/public-api-server/pkg/billingservice/mock_billingservice/billingservice.go
+++ b/components/public-api-server/pkg/billingservice/mock_billingservice/billingservice.go
@@ -47,7 +47,7 @@ func (m *MockInterface) FinalizeInvoice(ctx context.Context, invoiceId string) e
 }
 
 // FinalizeInvoice indicates an expected call of FinalizeInvoice.
-func (mr *MockInterfaceMockRecorder) FinalizeInvoice(ctx, invoiceId interface{}) *gomock.Call {
+func (mr *MockInterfaceMockRecorder) FinalizeInvoice(ctx, invoiceId any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FinalizeInvoice", reflect.TypeOf((*MockInterface)(nil).FinalizeInvoice), ctx, invoiceId)
 }

--- a/components/public-api/go/v1/pagination.pb.go
+++ b/components/public-api/go/v1/pagination.pb.go
@@ -110,7 +110,7 @@ func file_gitpod_v1_pagination_proto_rawDescGZIP() []byte {
 }
 
 var file_gitpod_v1_pagination_proto_msgTypes = make([]protoimpl.MessageInfo, 1)
-var file_gitpod_v1_pagination_proto_goTypes = []interface{}{
+var file_gitpod_v1_pagination_proto_goTypes = []any{
 	(*Pagination)(nil), // 0: gitpod.v1.Pagination
 }
 var file_gitpod_v1_pagination_proto_depIdxs = []int32{
@@ -127,7 +127,7 @@ func file_gitpod_v1_pagination_proto_init() {
 		return
 	}
 	if !protoimpl.UnsafeEnabled {
-		file_gitpod_v1_pagination_proto_msgTypes[0].Exporter = func(v interface{}, i int) interface{} {
+		file_gitpod_v1_pagination_proto_msgTypes[0].Exporter = func(v any, i int) any {
 			switch v := v.(*Pagination); i {
 			case 0:
 				return &v.state

--- a/components/public-api/go/v1/prebuilds.pb.go
+++ b/components/public-api/go/v1/prebuilds.pb.go
@@ -827,7 +827,7 @@ func file_gitpod_v1_prebuilds_proto_rawDescGZIP() []byte {
 
 var file_gitpod_v1_prebuilds_proto_enumTypes = make([]protoimpl.EnumInfo, 2)
 var file_gitpod_v1_prebuilds_proto_msgTypes = make([]protoimpl.MessageInfo, 11)
-var file_gitpod_v1_prebuilds_proto_goTypes = []interface{}{
+var file_gitpod_v1_prebuilds_proto_goTypes = []any{
 	(PrebuildStatus_Phase)(0),              // 0: gitpod.v1.PrebuildStatus.Phase
 	(PrebuildStatus_Result)(0),             // 1: gitpod.v1.PrebuildStatus.Result
 	(*GetPrebuildRequest)(nil),             // 2: gitpod.v1.GetPrebuildRequest
@@ -874,7 +874,7 @@ func file_gitpod_v1_prebuilds_proto_init() {
 	}
 	file_gitpod_v1_workspaces_proto_init()
 	if !protoimpl.UnsafeEnabled {
-		file_gitpod_v1_prebuilds_proto_msgTypes[0].Exporter = func(v interface{}, i int) interface{} {
+		file_gitpod_v1_prebuilds_proto_msgTypes[0].Exporter = func(v any, i int) any {
 			switch v := v.(*GetPrebuildRequest); i {
 			case 0:
 				return &v.state
@@ -886,7 +886,7 @@ func file_gitpod_v1_prebuilds_proto_init() {
 				return nil
 			}
 		}
-		file_gitpod_v1_prebuilds_proto_msgTypes[1].Exporter = func(v interface{}, i int) interface{} {
+		file_gitpod_v1_prebuilds_proto_msgTypes[1].Exporter = func(v any, i int) any {
 			switch v := v.(*GetPrebuildResponse); i {
 			case 0:
 				return &v.state
@@ -898,7 +898,7 @@ func file_gitpod_v1_prebuilds_proto_init() {
 				return nil
 			}
 		}
-		file_gitpod_v1_prebuilds_proto_msgTypes[2].Exporter = func(v interface{}, i int) interface{} {
+		file_gitpod_v1_prebuilds_proto_msgTypes[2].Exporter = func(v any, i int) any {
 			switch v := v.(*GetRunningPrebuildRequest); i {
 			case 0:
 				return &v.state
@@ -910,7 +910,7 @@ func file_gitpod_v1_prebuilds_proto_init() {
 				return nil
 			}
 		}
-		file_gitpod_v1_prebuilds_proto_msgTypes[3].Exporter = func(v interface{}, i int) interface{} {
+		file_gitpod_v1_prebuilds_proto_msgTypes[3].Exporter = func(v any, i int) any {
 			switch v := v.(*GetRunningPrebuildResponse); i {
 			case 0:
 				return &v.state
@@ -922,7 +922,7 @@ func file_gitpod_v1_prebuilds_proto_init() {
 				return nil
 			}
 		}
-		file_gitpod_v1_prebuilds_proto_msgTypes[4].Exporter = func(v interface{}, i int) interface{} {
+		file_gitpod_v1_prebuilds_proto_msgTypes[4].Exporter = func(v any, i int) any {
 			switch v := v.(*ListenToPrebuildStatusRequest); i {
 			case 0:
 				return &v.state
@@ -934,7 +934,7 @@ func file_gitpod_v1_prebuilds_proto_init() {
 				return nil
 			}
 		}
-		file_gitpod_v1_prebuilds_proto_msgTypes[5].Exporter = func(v interface{}, i int) interface{} {
+		file_gitpod_v1_prebuilds_proto_msgTypes[5].Exporter = func(v any, i int) any {
 			switch v := v.(*ListenToPrebuildStatusResponse); i {
 			case 0:
 				return &v.state
@@ -946,7 +946,7 @@ func file_gitpod_v1_prebuilds_proto_init() {
 				return nil
 			}
 		}
-		file_gitpod_v1_prebuilds_proto_msgTypes[6].Exporter = func(v interface{}, i int) interface{} {
+		file_gitpod_v1_prebuilds_proto_msgTypes[6].Exporter = func(v any, i int) any {
 			switch v := v.(*ListenToPrebuildLogsRequest); i {
 			case 0:
 				return &v.state
@@ -958,7 +958,7 @@ func file_gitpod_v1_prebuilds_proto_init() {
 				return nil
 			}
 		}
-		file_gitpod_v1_prebuilds_proto_msgTypes[7].Exporter = func(v interface{}, i int) interface{} {
+		file_gitpod_v1_prebuilds_proto_msgTypes[7].Exporter = func(v any, i int) any {
 			switch v := v.(*ListenToPrebuildLogsResponse); i {
 			case 0:
 				return &v.state
@@ -970,7 +970,7 @@ func file_gitpod_v1_prebuilds_proto_init() {
 				return nil
 			}
 		}
-		file_gitpod_v1_prebuilds_proto_msgTypes[8].Exporter = func(v interface{}, i int) interface{} {
+		file_gitpod_v1_prebuilds_proto_msgTypes[8].Exporter = func(v any, i int) any {
 			switch v := v.(*Prebuild); i {
 			case 0:
 				return &v.state
@@ -982,7 +982,7 @@ func file_gitpod_v1_prebuilds_proto_init() {
 				return nil
 			}
 		}
-		file_gitpod_v1_prebuilds_proto_msgTypes[9].Exporter = func(v interface{}, i int) interface{} {
+		file_gitpod_v1_prebuilds_proto_msgTypes[9].Exporter = func(v any, i int) any {
 			switch v := v.(*PrebuildSpec); i {
 			case 0:
 				return &v.state
@@ -994,7 +994,7 @@ func file_gitpod_v1_prebuilds_proto_init() {
 				return nil
 			}
 		}
-		file_gitpod_v1_prebuilds_proto_msgTypes[10].Exporter = func(v interface{}, i int) interface{} {
+		file_gitpod_v1_prebuilds_proto_msgTypes[10].Exporter = func(v any, i int) any {
 			switch v := v.(*PrebuildStatus); i {
 			case 0:
 				return &v.state

--- a/components/public-api/go/v1/prebuilds_grpc.pb.go
+++ b/components/public-api/go/v1/prebuilds_grpc.pb.go
@@ -180,7 +180,7 @@ func RegisterPrebuildsServiceServer(s grpc.ServiceRegistrar, srv PrebuildsServic
 	s.RegisterService(&PrebuildsService_ServiceDesc, srv)
 }
 
-func _PrebuildsService_GetPrebuild_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+func _PrebuildsService_GetPrebuild_Handler(srv any, ctx context.Context, dec func(any) error, interceptor grpc.UnaryServerInterceptor) (any, error) {
 	in := new(GetPrebuildRequest)
 	if err := dec(in); err != nil {
 		return nil, err
@@ -192,13 +192,13 @@ func _PrebuildsService_GetPrebuild_Handler(srv interface{}, ctx context.Context,
 		Server:     srv,
 		FullMethod: "/gitpod.v1.PrebuildsService/GetPrebuild",
 	}
-	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+	handler := func(ctx context.Context, req any) (any, error) {
 		return srv.(PrebuildsServiceServer).GetPrebuild(ctx, req.(*GetPrebuildRequest))
 	}
 	return interceptor(ctx, in, info, handler)
 }
 
-func _PrebuildsService_GetRunningPrebuild_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+func _PrebuildsService_GetRunningPrebuild_Handler(srv any, ctx context.Context, dec func(any) error, interceptor grpc.UnaryServerInterceptor) (any, error) {
 	in := new(GetRunningPrebuildRequest)
 	if err := dec(in); err != nil {
 		return nil, err
@@ -210,13 +210,13 @@ func _PrebuildsService_GetRunningPrebuild_Handler(srv interface{}, ctx context.C
 		Server:     srv,
 		FullMethod: "/gitpod.v1.PrebuildsService/GetRunningPrebuild",
 	}
-	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+	handler := func(ctx context.Context, req any) (any, error) {
 		return srv.(PrebuildsServiceServer).GetRunningPrebuild(ctx, req.(*GetRunningPrebuildRequest))
 	}
 	return interceptor(ctx, in, info, handler)
 }
 
-func _PrebuildsService_ListenToPrebuildStatus_Handler(srv interface{}, stream grpc.ServerStream) error {
+func _PrebuildsService_ListenToPrebuildStatus_Handler(srv any, stream grpc.ServerStream) error {
 	m := new(ListenToPrebuildStatusRequest)
 	if err := stream.RecvMsg(m); err != nil {
 		return err
@@ -237,7 +237,7 @@ func (x *prebuildsServiceListenToPrebuildStatusServer) Send(m *ListenToPrebuildS
 	return x.ServerStream.SendMsg(m)
 }
 
-func _PrebuildsService_ListenToPrebuildLogs_Handler(srv interface{}, stream grpc.ServerStream) error {
+func _PrebuildsService_ListenToPrebuildLogs_Handler(srv any, stream grpc.ServerStream) error {
 	m := new(ListenToPrebuildLogsRequest)
 	if err := stream.RecvMsg(m); err != nil {
 		return err

--- a/components/public-api/go/v1/workspaces.pb.go
+++ b/components/public-api/go/v1/workspaces.pb.go
@@ -2229,7 +2229,7 @@ func file_gitpod_v1_workspaces_proto_rawDescGZIP() []byte {
 
 var file_gitpod_v1_workspaces_proto_enumTypes = make([]protoimpl.EnumInfo, 2)
 var file_gitpod_v1_workspaces_proto_msgTypes = make([]protoimpl.MessageInfo, 30)
-var file_gitpod_v1_workspaces_proto_goTypes = []interface{}{
+var file_gitpod_v1_workspaces_proto_goTypes = []any{
 	(AdmissionLevel)(0),                                 // 0: gitpod.v1.AdmissionLevel
 	(WorkspaceInstanceStatus_Phase)(0),                  // 1: gitpod.v1.WorkspaceInstanceStatus.Phase
 	(*ListWorkspacesRequest)(nil),                       // 2: gitpod.v1.ListWorkspacesRequest
@@ -2322,7 +2322,7 @@ func file_gitpod_v1_workspaces_proto_init() {
 	}
 	file_gitpod_v1_pagination_proto_init()
 	if !protoimpl.UnsafeEnabled {
-		file_gitpod_v1_workspaces_proto_msgTypes[0].Exporter = func(v interface{}, i int) interface{} {
+		file_gitpod_v1_workspaces_proto_msgTypes[0].Exporter = func(v any, i int) any {
 			switch v := v.(*ListWorkspacesRequest); i {
 			case 0:
 				return &v.state
@@ -2334,7 +2334,7 @@ func file_gitpod_v1_workspaces_proto_init() {
 				return nil
 			}
 		}
-		file_gitpod_v1_workspaces_proto_msgTypes[1].Exporter = func(v interface{}, i int) interface{} {
+		file_gitpod_v1_workspaces_proto_msgTypes[1].Exporter = func(v any, i int) any {
 			switch v := v.(*ListWorkspacesResponse); i {
 			case 0:
 				return &v.state
@@ -2346,7 +2346,7 @@ func file_gitpod_v1_workspaces_proto_init() {
 				return nil
 			}
 		}
-		file_gitpod_v1_workspaces_proto_msgTypes[2].Exporter = func(v interface{}, i int) interface{} {
+		file_gitpod_v1_workspaces_proto_msgTypes[2].Exporter = func(v any, i int) any {
 			switch v := v.(*GetWorkspaceRequest); i {
 			case 0:
 				return &v.state
@@ -2358,7 +2358,7 @@ func file_gitpod_v1_workspaces_proto_init() {
 				return nil
 			}
 		}
-		file_gitpod_v1_workspaces_proto_msgTypes[3].Exporter = func(v interface{}, i int) interface{} {
+		file_gitpod_v1_workspaces_proto_msgTypes[3].Exporter = func(v any, i int) any {
 			switch v := v.(*GetWorkspaceResponse); i {
 			case 0:
 				return &v.state
@@ -2370,7 +2370,7 @@ func file_gitpod_v1_workspaces_proto_init() {
 				return nil
 			}
 		}
-		file_gitpod_v1_workspaces_proto_msgTypes[4].Exporter = func(v interface{}, i int) interface{} {
+		file_gitpod_v1_workspaces_proto_msgTypes[4].Exporter = func(v any, i int) any {
 			switch v := v.(*GetOwnerTokenRequest); i {
 			case 0:
 				return &v.state
@@ -2382,7 +2382,7 @@ func file_gitpod_v1_workspaces_proto_init() {
 				return nil
 			}
 		}
-		file_gitpod_v1_workspaces_proto_msgTypes[5].Exporter = func(v interface{}, i int) interface{} {
+		file_gitpod_v1_workspaces_proto_msgTypes[5].Exporter = func(v any, i int) any {
 			switch v := v.(*GetOwnerTokenResponse); i {
 			case 0:
 				return &v.state
@@ -2394,7 +2394,7 @@ func file_gitpod_v1_workspaces_proto_init() {
 				return nil
 			}
 		}
-		file_gitpod_v1_workspaces_proto_msgTypes[6].Exporter = func(v interface{}, i int) interface{} {
+		file_gitpod_v1_workspaces_proto_msgTypes[6].Exporter = func(v any, i int) any {
 			switch v := v.(*CreateAndStartWorkspaceRequest); i {
 			case 0:
 				return &v.state
@@ -2406,7 +2406,7 @@ func file_gitpod_v1_workspaces_proto_init() {
 				return nil
 			}
 		}
-		file_gitpod_v1_workspaces_proto_msgTypes[7].Exporter = func(v interface{}, i int) interface{} {
+		file_gitpod_v1_workspaces_proto_msgTypes[7].Exporter = func(v any, i int) any {
 			switch v := v.(*CreateAndStartWorkspaceResponse); i {
 			case 0:
 				return &v.state
@@ -2418,7 +2418,7 @@ func file_gitpod_v1_workspaces_proto_init() {
 				return nil
 			}
 		}
-		file_gitpod_v1_workspaces_proto_msgTypes[8].Exporter = func(v interface{}, i int) interface{} {
+		file_gitpod_v1_workspaces_proto_msgTypes[8].Exporter = func(v any, i int) any {
 			switch v := v.(*StartWorkspaceRequest); i {
 			case 0:
 				return &v.state
@@ -2430,7 +2430,7 @@ func file_gitpod_v1_workspaces_proto_init() {
 				return nil
 			}
 		}
-		file_gitpod_v1_workspaces_proto_msgTypes[9].Exporter = func(v interface{}, i int) interface{} {
+		file_gitpod_v1_workspaces_proto_msgTypes[9].Exporter = func(v any, i int) any {
 			switch v := v.(*StartWorkspaceResponse); i {
 			case 0:
 				return &v.state
@@ -2442,7 +2442,7 @@ func file_gitpod_v1_workspaces_proto_init() {
 				return nil
 			}
 		}
-		file_gitpod_v1_workspaces_proto_msgTypes[10].Exporter = func(v interface{}, i int) interface{} {
+		file_gitpod_v1_workspaces_proto_msgTypes[10].Exporter = func(v any, i int) any {
 			switch v := v.(*GetActiveWorkspaceInstanceRequest); i {
 			case 0:
 				return &v.state
@@ -2454,7 +2454,7 @@ func file_gitpod_v1_workspaces_proto_init() {
 				return nil
 			}
 		}
-		file_gitpod_v1_workspaces_proto_msgTypes[11].Exporter = func(v interface{}, i int) interface{} {
+		file_gitpod_v1_workspaces_proto_msgTypes[11].Exporter = func(v any, i int) any {
 			switch v := v.(*GetActiveWorkspaceInstanceResponse); i {
 			case 0:
 				return &v.state
@@ -2466,7 +2466,7 @@ func file_gitpod_v1_workspaces_proto_init() {
 				return nil
 			}
 		}
-		file_gitpod_v1_workspaces_proto_msgTypes[12].Exporter = func(v interface{}, i int) interface{} {
+		file_gitpod_v1_workspaces_proto_msgTypes[12].Exporter = func(v any, i int) any {
 			switch v := v.(*GetWorkspaceInstanceOwnerTokenRequest); i {
 			case 0:
 				return &v.state
@@ -2478,7 +2478,7 @@ func file_gitpod_v1_workspaces_proto_init() {
 				return nil
 			}
 		}
-		file_gitpod_v1_workspaces_proto_msgTypes[13].Exporter = func(v interface{}, i int) interface{} {
+		file_gitpod_v1_workspaces_proto_msgTypes[13].Exporter = func(v any, i int) any {
 			switch v := v.(*GetWorkspaceInstanceOwnerTokenResponse); i {
 			case 0:
 				return &v.state
@@ -2490,7 +2490,7 @@ func file_gitpod_v1_workspaces_proto_init() {
 				return nil
 			}
 		}
-		file_gitpod_v1_workspaces_proto_msgTypes[14].Exporter = func(v interface{}, i int) interface{} {
+		file_gitpod_v1_workspaces_proto_msgTypes[14].Exporter = func(v any, i int) any {
 			switch v := v.(*ListenToWorkspaceInstanceRequest); i {
 			case 0:
 				return &v.state
@@ -2502,7 +2502,7 @@ func file_gitpod_v1_workspaces_proto_init() {
 				return nil
 			}
 		}
-		file_gitpod_v1_workspaces_proto_msgTypes[15].Exporter = func(v interface{}, i int) interface{} {
+		file_gitpod_v1_workspaces_proto_msgTypes[15].Exporter = func(v any, i int) any {
 			switch v := v.(*ListenToWorkspaceInstanceResponse); i {
 			case 0:
 				return &v.state
@@ -2514,7 +2514,7 @@ func file_gitpod_v1_workspaces_proto_init() {
 				return nil
 			}
 		}
-		file_gitpod_v1_workspaces_proto_msgTypes[16].Exporter = func(v interface{}, i int) interface{} {
+		file_gitpod_v1_workspaces_proto_msgTypes[16].Exporter = func(v any, i int) any {
 			switch v := v.(*ListenToImageBuildLogsRequest); i {
 			case 0:
 				return &v.state
@@ -2526,7 +2526,7 @@ func file_gitpod_v1_workspaces_proto_init() {
 				return nil
 			}
 		}
-		file_gitpod_v1_workspaces_proto_msgTypes[17].Exporter = func(v interface{}, i int) interface{} {
+		file_gitpod_v1_workspaces_proto_msgTypes[17].Exporter = func(v any, i int) any {
 			switch v := v.(*ListenToImageBuildLogsResponse); i {
 			case 0:
 				return &v.state
@@ -2538,7 +2538,7 @@ func file_gitpod_v1_workspaces_proto_init() {
 				return nil
 			}
 		}
-		file_gitpod_v1_workspaces_proto_msgTypes[18].Exporter = func(v interface{}, i int) interface{} {
+		file_gitpod_v1_workspaces_proto_msgTypes[18].Exporter = func(v any, i int) any {
 			switch v := v.(*StopWorkspaceRequest); i {
 			case 0:
 				return &v.state
@@ -2550,7 +2550,7 @@ func file_gitpod_v1_workspaces_proto_init() {
 				return nil
 			}
 		}
-		file_gitpod_v1_workspaces_proto_msgTypes[19].Exporter = func(v interface{}, i int) interface{} {
+		file_gitpod_v1_workspaces_proto_msgTypes[19].Exporter = func(v any, i int) any {
 			switch v := v.(*StopWorkspaceResponse); i {
 			case 0:
 				return &v.state
@@ -2562,7 +2562,7 @@ func file_gitpod_v1_workspaces_proto_init() {
 				return nil
 			}
 		}
-		file_gitpod_v1_workspaces_proto_msgTypes[20].Exporter = func(v interface{}, i int) interface{} {
+		file_gitpod_v1_workspaces_proto_msgTypes[20].Exporter = func(v any, i int) any {
 			switch v := v.(*Workspace); i {
 			case 0:
 				return &v.state
@@ -2574,7 +2574,7 @@ func file_gitpod_v1_workspaces_proto_init() {
 				return nil
 			}
 		}
-		file_gitpod_v1_workspaces_proto_msgTypes[21].Exporter = func(v interface{}, i int) interface{} {
+		file_gitpod_v1_workspaces_proto_msgTypes[21].Exporter = func(v any, i int) any {
 			switch v := v.(*WorkspaceContext); i {
 			case 0:
 				return &v.state
@@ -2586,7 +2586,7 @@ func file_gitpod_v1_workspaces_proto_init() {
 				return nil
 			}
 		}
-		file_gitpod_v1_workspaces_proto_msgTypes[22].Exporter = func(v interface{}, i int) interface{} {
+		file_gitpod_v1_workspaces_proto_msgTypes[22].Exporter = func(v any, i int) any {
 			switch v := v.(*WorkspaceInstance); i {
 			case 0:
 				return &v.state
@@ -2598,7 +2598,7 @@ func file_gitpod_v1_workspaces_proto_init() {
 				return nil
 			}
 		}
-		file_gitpod_v1_workspaces_proto_msgTypes[23].Exporter = func(v interface{}, i int) interface{} {
+		file_gitpod_v1_workspaces_proto_msgTypes[23].Exporter = func(v any, i int) any {
 			switch v := v.(*WorkspaceInstanceStatus); i {
 			case 0:
 				return &v.state
@@ -2610,7 +2610,7 @@ func file_gitpod_v1_workspaces_proto_init() {
 				return nil
 			}
 		}
-		file_gitpod_v1_workspaces_proto_msgTypes[24].Exporter = func(v interface{}, i int) interface{} {
+		file_gitpod_v1_workspaces_proto_msgTypes[24].Exporter = func(v any, i int) any {
 			switch v := v.(*StartWorkspaceSpec); i {
 			case 0:
 				return &v.state
@@ -2622,7 +2622,7 @@ func file_gitpod_v1_workspaces_proto_init() {
 				return nil
 			}
 		}
-		file_gitpod_v1_workspaces_proto_msgTypes[25].Exporter = func(v interface{}, i int) interface{} {
+		file_gitpod_v1_workspaces_proto_msgTypes[25].Exporter = func(v any, i int) any {
 			switch v := v.(*ListWorkspacesResponse_WorkspaceAndInstance); i {
 			case 0:
 				return &v.state
@@ -2634,7 +2634,7 @@ func file_gitpod_v1_workspaces_proto_init() {
 				return nil
 			}
 		}
-		file_gitpod_v1_workspaces_proto_msgTypes[26].Exporter = func(v interface{}, i int) interface{} {
+		file_gitpod_v1_workspaces_proto_msgTypes[26].Exporter = func(v any, i int) any {
 			switch v := v.(*WorkspaceContext_Git); i {
 			case 0:
 				return &v.state
@@ -2646,7 +2646,7 @@ func file_gitpod_v1_workspaces_proto_init() {
 				return nil
 			}
 		}
-		file_gitpod_v1_workspaces_proto_msgTypes[27].Exporter = func(v interface{}, i int) interface{} {
+		file_gitpod_v1_workspaces_proto_msgTypes[27].Exporter = func(v any, i int) any {
 			switch v := v.(*WorkspaceContext_Prebuild); i {
 			case 0:
 				return &v.state
@@ -2658,7 +2658,7 @@ func file_gitpod_v1_workspaces_proto_init() {
 				return nil
 			}
 		}
-		file_gitpod_v1_workspaces_proto_msgTypes[28].Exporter = func(v interface{}, i int) interface{} {
+		file_gitpod_v1_workspaces_proto_msgTypes[28].Exporter = func(v any, i int) any {
 			switch v := v.(*WorkspaceContext_Snapshot); i {
 			case 0:
 				return &v.state
@@ -2670,7 +2670,7 @@ func file_gitpod_v1_workspaces_proto_init() {
 				return nil
 			}
 		}
-		file_gitpod_v1_workspaces_proto_msgTypes[29].Exporter = func(v interface{}, i int) interface{} {
+		file_gitpod_v1_workspaces_proto_msgTypes[29].Exporter = func(v any, i int) any {
 			switch v := v.(*WorkspaceInstanceStatus_Conditions); i {
 			case 0:
 				return &v.state
@@ -2683,16 +2683,16 @@ func file_gitpod_v1_workspaces_proto_init() {
 			}
 		}
 	}
-	file_gitpod_v1_workspaces_proto_msgTypes[6].OneofWrappers = []interface{}{
+	file_gitpod_v1_workspaces_proto_msgTypes[6].OneofWrappers = []any{
 		(*CreateAndStartWorkspaceRequest_ContextUrl)(nil),
 		(*CreateAndStartWorkspaceRequest_PrebuildId)(nil),
 	}
-	file_gitpod_v1_workspaces_proto_msgTypes[21].OneofWrappers = []interface{}{
+	file_gitpod_v1_workspaces_proto_msgTypes[21].OneofWrappers = []any{
 		(*WorkspaceContext_Git_)(nil),
 		(*WorkspaceContext_Prebuild_)(nil),
 		(*WorkspaceContext_Snapshot_)(nil),
 	}
-	file_gitpod_v1_workspaces_proto_msgTypes[29].OneofWrappers = []interface{}{}
+	file_gitpod_v1_workspaces_proto_msgTypes[29].OneofWrappers = []any{}
 	type x struct{}
 	out := protoimpl.TypeBuilder{
 		File: protoimpl.DescBuilder{

--- a/components/public-api/go/v1/workspaces_grpc.pb.go
+++ b/components/public-api/go/v1/workspaces_grpc.pb.go
@@ -305,7 +305,7 @@ func RegisterWorkspacesServiceServer(s grpc.ServiceRegistrar, srv WorkspacesServ
 	s.RegisterService(&WorkspacesService_ServiceDesc, srv)
 }
 
-func _WorkspacesService_ListWorkspaces_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+func _WorkspacesService_ListWorkspaces_Handler(srv any, ctx context.Context, dec func(any) error, interceptor grpc.UnaryServerInterceptor) (any, error) {
 	in := new(ListWorkspacesRequest)
 	if err := dec(in); err != nil {
 		return nil, err
@@ -317,13 +317,13 @@ func _WorkspacesService_ListWorkspaces_Handler(srv interface{}, ctx context.Cont
 		Server:     srv,
 		FullMethod: "/gitpod.v1.WorkspacesService/ListWorkspaces",
 	}
-	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+	handler := func(ctx context.Context, req any) (any, error) {
 		return srv.(WorkspacesServiceServer).ListWorkspaces(ctx, req.(*ListWorkspacesRequest))
 	}
 	return interceptor(ctx, in, info, handler)
 }
 
-func _WorkspacesService_GetWorkspace_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+func _WorkspacesService_GetWorkspace_Handler(srv any, ctx context.Context, dec func(any) error, interceptor grpc.UnaryServerInterceptor) (any, error) {
 	in := new(GetWorkspaceRequest)
 	if err := dec(in); err != nil {
 		return nil, err
@@ -335,13 +335,13 @@ func _WorkspacesService_GetWorkspace_Handler(srv interface{}, ctx context.Contex
 		Server:     srv,
 		FullMethod: "/gitpod.v1.WorkspacesService/GetWorkspace",
 	}
-	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+	handler := func(ctx context.Context, req any) (any, error) {
 		return srv.(WorkspacesServiceServer).GetWorkspace(ctx, req.(*GetWorkspaceRequest))
 	}
 	return interceptor(ctx, in, info, handler)
 }
 
-func _WorkspacesService_GetOwnerToken_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+func _WorkspacesService_GetOwnerToken_Handler(srv any, ctx context.Context, dec func(any) error, interceptor grpc.UnaryServerInterceptor) (any, error) {
 	in := new(GetOwnerTokenRequest)
 	if err := dec(in); err != nil {
 		return nil, err
@@ -353,13 +353,13 @@ func _WorkspacesService_GetOwnerToken_Handler(srv interface{}, ctx context.Conte
 		Server:     srv,
 		FullMethod: "/gitpod.v1.WorkspacesService/GetOwnerToken",
 	}
-	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+	handler := func(ctx context.Context, req any) (any, error) {
 		return srv.(WorkspacesServiceServer).GetOwnerToken(ctx, req.(*GetOwnerTokenRequest))
 	}
 	return interceptor(ctx, in, info, handler)
 }
 
-func _WorkspacesService_CreateAndStartWorkspace_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+func _WorkspacesService_CreateAndStartWorkspace_Handler(srv any, ctx context.Context, dec func(any) error, interceptor grpc.UnaryServerInterceptor) (any, error) {
 	in := new(CreateAndStartWorkspaceRequest)
 	if err := dec(in); err != nil {
 		return nil, err
@@ -371,13 +371,13 @@ func _WorkspacesService_CreateAndStartWorkspace_Handler(srv interface{}, ctx con
 		Server:     srv,
 		FullMethod: "/gitpod.v1.WorkspacesService/CreateAndStartWorkspace",
 	}
-	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+	handler := func(ctx context.Context, req any) (any, error) {
 		return srv.(WorkspacesServiceServer).CreateAndStartWorkspace(ctx, req.(*CreateAndStartWorkspaceRequest))
 	}
 	return interceptor(ctx, in, info, handler)
 }
 
-func _WorkspacesService_StartWorkspace_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+func _WorkspacesService_StartWorkspace_Handler(srv any, ctx context.Context, dec func(any) error, interceptor grpc.UnaryServerInterceptor) (any, error) {
 	in := new(StartWorkspaceRequest)
 	if err := dec(in); err != nil {
 		return nil, err
@@ -389,13 +389,13 @@ func _WorkspacesService_StartWorkspace_Handler(srv interface{}, ctx context.Cont
 		Server:     srv,
 		FullMethod: "/gitpod.v1.WorkspacesService/StartWorkspace",
 	}
-	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+	handler := func(ctx context.Context, req any) (any, error) {
 		return srv.(WorkspacesServiceServer).StartWorkspace(ctx, req.(*StartWorkspaceRequest))
 	}
 	return interceptor(ctx, in, info, handler)
 }
 
-func _WorkspacesService_GetActiveWorkspaceInstance_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+func _WorkspacesService_GetActiveWorkspaceInstance_Handler(srv any, ctx context.Context, dec func(any) error, interceptor grpc.UnaryServerInterceptor) (any, error) {
 	in := new(GetActiveWorkspaceInstanceRequest)
 	if err := dec(in); err != nil {
 		return nil, err
@@ -407,13 +407,13 @@ func _WorkspacesService_GetActiveWorkspaceInstance_Handler(srv interface{}, ctx 
 		Server:     srv,
 		FullMethod: "/gitpod.v1.WorkspacesService/GetActiveWorkspaceInstance",
 	}
-	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+	handler := func(ctx context.Context, req any) (any, error) {
 		return srv.(WorkspacesServiceServer).GetActiveWorkspaceInstance(ctx, req.(*GetActiveWorkspaceInstanceRequest))
 	}
 	return interceptor(ctx, in, info, handler)
 }
 
-func _WorkspacesService_GetWorkspaceInstanceOwnerToken_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+func _WorkspacesService_GetWorkspaceInstanceOwnerToken_Handler(srv any, ctx context.Context, dec func(any) error, interceptor grpc.UnaryServerInterceptor) (any, error) {
 	in := new(GetWorkspaceInstanceOwnerTokenRequest)
 	if err := dec(in); err != nil {
 		return nil, err
@@ -425,13 +425,13 @@ func _WorkspacesService_GetWorkspaceInstanceOwnerToken_Handler(srv interface{}, 
 		Server:     srv,
 		FullMethod: "/gitpod.v1.WorkspacesService/GetWorkspaceInstanceOwnerToken",
 	}
-	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+	handler := func(ctx context.Context, req any) (any, error) {
 		return srv.(WorkspacesServiceServer).GetWorkspaceInstanceOwnerToken(ctx, req.(*GetWorkspaceInstanceOwnerTokenRequest))
 	}
 	return interceptor(ctx, in, info, handler)
 }
 
-func _WorkspacesService_ListenToWorkspaceInstance_Handler(srv interface{}, stream grpc.ServerStream) error {
+func _WorkspacesService_ListenToWorkspaceInstance_Handler(srv any, stream grpc.ServerStream) error {
 	m := new(ListenToWorkspaceInstanceRequest)
 	if err := stream.RecvMsg(m); err != nil {
 		return err
@@ -452,7 +452,7 @@ func (x *workspacesServiceListenToWorkspaceInstanceServer) Send(m *ListenToWorks
 	return x.ServerStream.SendMsg(m)
 }
 
-func _WorkspacesService_ListenToImageBuildLogs_Handler(srv interface{}, stream grpc.ServerStream) error {
+func _WorkspacesService_ListenToImageBuildLogs_Handler(srv any, stream grpc.ServerStream) error {
 	m := new(ListenToImageBuildLogsRequest)
 	if err := stream.RecvMsg(m); err != nil {
 		return err
@@ -473,7 +473,7 @@ func (x *workspacesServiceListenToImageBuildLogsServer) Send(m *ListenToImageBui
 	return x.ServerStream.SendMsg(m)
 }
 
-func _WorkspacesService_StopWorkspace_Handler(srv interface{}, stream grpc.ServerStream) error {
+func _WorkspacesService_StopWorkspace_Handler(srv any, stream grpc.ServerStream) error {
 	m := new(StopWorkspaceRequest)
 	if err := stream.RecvMsg(m); err != nil {
 		return err

--- a/components/registry-facade-api/go/imagespec.pb.go
+++ b/components/registry-facade-api/go/imagespec.pb.go
@@ -404,7 +404,7 @@ func file_imagespec_proto_rawDescGZIP() []byte {
 }
 
 var file_imagespec_proto_msgTypes = make([]protoimpl.MessageInfo, 4)
-var file_imagespec_proto_goTypes = []interface{}{
+var file_imagespec_proto_goTypes = []any{
 	(*ImageSpec)(nil),          // 0: registryfacade.ImageSpec
 	(*ContentLayer)(nil),       // 1: registryfacade.ContentLayer
 	(*RemoteContentLayer)(nil), // 2: registryfacade.RemoteContentLayer
@@ -427,7 +427,7 @@ func file_imagespec_proto_init() {
 		return
 	}
 	if !protoimpl.UnsafeEnabled {
-		file_imagespec_proto_msgTypes[0].Exporter = func(v interface{}, i int) interface{} {
+		file_imagespec_proto_msgTypes[0].Exporter = func(v any, i int) any {
 			switch v := v.(*ImageSpec); i {
 			case 0:
 				return &v.state
@@ -439,7 +439,7 @@ func file_imagespec_proto_init() {
 				return nil
 			}
 		}
-		file_imagespec_proto_msgTypes[1].Exporter = func(v interface{}, i int) interface{} {
+		file_imagespec_proto_msgTypes[1].Exporter = func(v any, i int) any {
 			switch v := v.(*ContentLayer); i {
 			case 0:
 				return &v.state
@@ -451,7 +451,7 @@ func file_imagespec_proto_init() {
 				return nil
 			}
 		}
-		file_imagespec_proto_msgTypes[2].Exporter = func(v interface{}, i int) interface{} {
+		file_imagespec_proto_msgTypes[2].Exporter = func(v any, i int) any {
 			switch v := v.(*RemoteContentLayer); i {
 			case 0:
 				return &v.state
@@ -463,7 +463,7 @@ func file_imagespec_proto_init() {
 				return nil
 			}
 		}
-		file_imagespec_proto_msgTypes[3].Exporter = func(v interface{}, i int) interface{} {
+		file_imagespec_proto_msgTypes[3].Exporter = func(v any, i int) any {
 			switch v := v.(*DirectContentLayer); i {
 			case 0:
 				return &v.state
@@ -476,7 +476,7 @@ func file_imagespec_proto_init() {
 			}
 		}
 	}
-	file_imagespec_proto_msgTypes[1].OneofWrappers = []interface{}{
+	file_imagespec_proto_msgTypes[1].OneofWrappers = []any{
 		(*ContentLayer_Remote)(nil),
 		(*ContentLayer_Direct)(nil),
 	}

--- a/components/registry-facade-api/go/provider.pb.go
+++ b/components/registry-facade-api/go/provider.pb.go
@@ -157,7 +157,7 @@ func file_provider_proto_rawDescGZIP() []byte {
 }
 
 var file_provider_proto_msgTypes = make([]protoimpl.MessageInfo, 2)
-var file_provider_proto_goTypes = []interface{}{
+var file_provider_proto_goTypes = []any{
 	(*GetImageSpecRequest)(nil),  // 0: registryfacade.GetImageSpecRequest
 	(*GetImageSpecResponse)(nil), // 1: registryfacade.GetImageSpecResponse
 	(*ImageSpec)(nil),            // 2: registryfacade.ImageSpec
@@ -180,7 +180,7 @@ func file_provider_proto_init() {
 	}
 	file_imagespec_proto_init()
 	if !protoimpl.UnsafeEnabled {
-		file_provider_proto_msgTypes[0].Exporter = func(v interface{}, i int) interface{} {
+		file_provider_proto_msgTypes[0].Exporter = func(v any, i int) any {
 			switch v := v.(*GetImageSpecRequest); i {
 			case 0:
 				return &v.state
@@ -192,7 +192,7 @@ func file_provider_proto_init() {
 				return nil
 			}
 		}
-		file_provider_proto_msgTypes[1].Exporter = func(v interface{}, i int) interface{} {
+		file_provider_proto_msgTypes[1].Exporter = func(v any, i int) any {
 			switch v := v.(*GetImageSpecResponse); i {
 			case 0:
 				return &v.state

--- a/components/registry-facade-api/go/provider_grpc.pb.go
+++ b/components/registry-facade-api/go/provider_grpc.pb.go
@@ -80,7 +80,7 @@ func RegisterSpecProviderServer(s grpc.ServiceRegistrar, srv SpecProviderServer)
 	s.RegisterService(&SpecProvider_ServiceDesc, srv)
 }
 
-func _SpecProvider_GetImageSpec_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+func _SpecProvider_GetImageSpec_Handler(srv any, ctx context.Context, dec func(any) error, interceptor grpc.UnaryServerInterceptor) (any, error) {
 	in := new(GetImageSpecRequest)
 	if err := dec(in); err != nil {
 		return nil, err
@@ -92,7 +92,7 @@ func _SpecProvider_GetImageSpec_Handler(srv interface{}, ctx context.Context, de
 		Server:     srv,
 		FullMethod: "/registryfacade.SpecProvider/GetImageSpec",
 	}
-	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+	handler := func(ctx context.Context, req any) (any, error) {
 		return srv.(SpecProviderServer).GetImageSpec(ctx, req.(*GetImageSpecRequest))
 	}
 	return interceptor(ctx, in, info, handler)

--- a/components/registry-facade/pkg/registry/blob.go
+++ b/components/registry-facade/pkg/registry/blob.go
@@ -96,7 +96,7 @@ type blobHandler struct {
 }
 
 var bufPool = sync.Pool{
-	New: func() interface{} {
+	New: func() any {
 		// setting to 4096 to align with PIPE_BUF
 		// http://man7.org/linux/man-pages/man7/pipe.7.html
 		buffer := make([]byte, 4096)

--- a/components/registry-facade/pkg/registry/cache.go
+++ b/components/registry-facade/pkg/registry/cache.go
@@ -237,7 +237,7 @@ func (w *redisBlobWriter) Commit(ctx context.Context, size int64, expected diges
 		return nil
 	}
 
-	err = w.client.MSet(ctx, map[string]interface{}{
+	err = w.client.MSet(ctx, map[string]any{
 		kContent: w.buf.String(),
 		kInfo:    string(rnfo),
 	}).Err()

--- a/components/registry-facade/pkg/registry/http_client.go
+++ b/components/registry-facade/pkg/registry/http_client.go
@@ -88,8 +88,8 @@ type leveledLogrus struct {
 	*logrus.Entry
 }
 
-func (l *leveledLogrus) fields(keysAndValues ...interface{}) map[string]interface{} {
-	fields := make(map[string]interface{})
+func (l *leveledLogrus) fields(keysAndValues ...any) map[string]any {
+	fields := make(map[string]any)
 
 	for i := 0; i < len(keysAndValues)-1; i += 2 {
 		fields[keysAndValues[i].(string)] = keysAndValues[i+1]
@@ -98,18 +98,18 @@ func (l *leveledLogrus) fields(keysAndValues ...interface{}) map[string]interfac
 	return fields
 }
 
-func (l *leveledLogrus) Error(msg string, keysAndValues ...interface{}) {
+func (l *leveledLogrus) Error(msg string, keysAndValues ...any) {
 	l.WithFields(l.fields(keysAndValues...)).Error(msg)
 }
 
-func (l *leveledLogrus) Info(msg string, keysAndValues ...interface{}) {
+func (l *leveledLogrus) Info(msg string, keysAndValues ...any) {
 	l.WithFields(l.fields(keysAndValues...)).Info(msg)
 }
 
-func (l *leveledLogrus) Debug(msg string, keysAndValues ...interface{}) {
+func (l *leveledLogrus) Debug(msg string, keysAndValues ...any) {
 	l.WithFields(l.fields(keysAndValues...)).Debug(msg)
 }
 
-func (l *leveledLogrus) Warn(msg string, keysAndValues ...interface{}) {
+func (l *leveledLogrus) Warn(msg string, keysAndValues ...any) {
 	l.WithFields(l.fields(keysAndValues...)).Warn(msg)
 }

--- a/components/registry-facade/pkg/registry/layersource_test.go
+++ b/components/registry-facade/pkg/registry/layersource_test.go
@@ -62,7 +62,7 @@ func TestStaticLayerSource(t *testing.T) {
 	test := ctesting.FixtureTest{
 		T:    t,
 		Path: "fixtures/layersrc_*.json",
-		Test: func(t *testing.T, input interface{}) interface{} {
+		Test: func(t *testing.T, input any) any {
 			fixture := input.(*testStaticLayerSourceFixture)
 
 			src, err := NewStaticSourceFromImage(context.Background(), &fakeFetcher{Content: fixture.Content}, fixture.SourceRef)
@@ -80,8 +80,8 @@ func TestStaticLayerSource(t *testing.T) {
 			}
 			return &gold{Layer: res, Envs: envs.serialize()}
 		},
-		Fixture: func() interface{} { return &testStaticLayerSourceFixture{} },
-		Gold:    func() interface{} { return &gold{} },
+		Fixture: func() any { return &testStaticLayerSourceFixture{} },
+		Gold:    func() any { return &gold{} },
 	}
 	test.Run()
 }

--- a/components/registry-facade/pkg/registry/mock/layersource_mock.go
+++ b/components/registry-facade/pkg/registry/mock/layersource_mock.go
@@ -52,7 +52,7 @@ func (m *MockLayerSource) Envs(arg0 context.Context, arg1 *api.ImageSpec) ([]reg
 }
 
 // Envs indicates an expected call of Envs.
-func (mr *MockLayerSourceMockRecorder) Envs(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockLayerSourceMockRecorder) Envs(arg0, arg1 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Envs", reflect.TypeOf((*MockLayerSource)(nil).Envs), arg0, arg1)
 }
@@ -70,7 +70,7 @@ func (m *MockLayerSource) GetBlob(arg0 context.Context, arg1 *api.ImageSpec, arg
 }
 
 // GetBlob indicates an expected call of GetBlob.
-func (mr *MockLayerSourceMockRecorder) GetBlob(arg0, arg1, arg2 interface{}) *gomock.Call {
+func (mr *MockLayerSourceMockRecorder) GetBlob(arg0, arg1, arg2 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetBlob", reflect.TypeOf((*MockLayerSource)(nil).GetBlob), arg0, arg1, arg2)
 }
@@ -85,7 +85,7 @@ func (m *MockLayerSource) GetLayer(arg0 context.Context, arg1 *api.ImageSpec) ([
 }
 
 // GetLayer indicates an expected call of GetLayer.
-func (mr *MockLayerSourceMockRecorder) GetLayer(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockLayerSourceMockRecorder) GetLayer(arg0, arg1 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetLayer", reflect.TypeOf((*MockLayerSource)(nil).GetLayer), arg0, arg1)
 }
@@ -99,7 +99,7 @@ func (m *MockLayerSource) HasBlob(arg0 context.Context, arg1 *api.ImageSpec, arg
 }
 
 // HasBlob indicates an expected call of HasBlob.
-func (mr *MockLayerSourceMockRecorder) HasBlob(arg0, arg1, arg2 interface{}) *gomock.Call {
+func (mr *MockLayerSourceMockRecorder) HasBlob(arg0, arg1, arg2 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HasBlob", reflect.TypeOf((*MockLayerSource)(nil).HasBlob), arg0, arg1, arg2)
 }

--- a/components/registry-facade/pkg/registry/registry.go
+++ b/components/registry-facade/pkg/registry/registry.go
@@ -507,7 +507,7 @@ type muxVarsContext struct {
 	vars map[string]string
 }
 
-func (ctx *muxVarsContext) Value(key interface{}) interface{} {
+func (ctx *muxVarsContext) Value(key any) any {
 	if keyStr, ok := key.(string); ok {
 		if keyStr == "vars" {
 			return ctx.vars

--- a/components/supervisor-api/go/control.pb.go
+++ b/components/supervisor-api/go/control.pb.go
@@ -243,7 +243,7 @@ func file_control_proto_rawDescGZIP() []byte {
 }
 
 var file_control_proto_msgTypes = make([]protoimpl.MessageInfo, 4)
-var file_control_proto_goTypes = []interface{}{
+var file_control_proto_goTypes = []any{
 	(*ExposePortRequest)(nil),        // 0: supervisor.ExposePortRequest
 	(*ExposePortResponse)(nil),       // 1: supervisor.ExposePortResponse
 	(*CreateSSHKeyPairRequest)(nil),  // 2: supervisor.CreateSSHKeyPairRequest
@@ -267,7 +267,7 @@ func file_control_proto_init() {
 		return
 	}
 	if !protoimpl.UnsafeEnabled {
-		file_control_proto_msgTypes[0].Exporter = func(v interface{}, i int) interface{} {
+		file_control_proto_msgTypes[0].Exporter = func(v any, i int) any {
 			switch v := v.(*ExposePortRequest); i {
 			case 0:
 				return &v.state
@@ -279,7 +279,7 @@ func file_control_proto_init() {
 				return nil
 			}
 		}
-		file_control_proto_msgTypes[1].Exporter = func(v interface{}, i int) interface{} {
+		file_control_proto_msgTypes[1].Exporter = func(v any, i int) any {
 			switch v := v.(*ExposePortResponse); i {
 			case 0:
 				return &v.state
@@ -291,7 +291,7 @@ func file_control_proto_init() {
 				return nil
 			}
 		}
-		file_control_proto_msgTypes[2].Exporter = func(v interface{}, i int) interface{} {
+		file_control_proto_msgTypes[2].Exporter = func(v any, i int) any {
 			switch v := v.(*CreateSSHKeyPairRequest); i {
 			case 0:
 				return &v.state
@@ -303,7 +303,7 @@ func file_control_proto_init() {
 				return nil
 			}
 		}
-		file_control_proto_msgTypes[3].Exporter = func(v interface{}, i int) interface{} {
+		file_control_proto_msgTypes[3].Exporter = func(v any, i int) any {
 			switch v := v.(*CreateSSHKeyPairResponse); i {
 			case 0:
 				return &v.state

--- a/components/supervisor-api/go/control_grpc.pb.go
+++ b/components/supervisor-api/go/control_grpc.pb.go
@@ -92,7 +92,7 @@ func RegisterControlServiceServer(s grpc.ServiceRegistrar, srv ControlServiceSer
 	s.RegisterService(&ControlService_ServiceDesc, srv)
 }
 
-func _ControlService_ExposePort_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+func _ControlService_ExposePort_Handler(srv any, ctx context.Context, dec func(any) error, interceptor grpc.UnaryServerInterceptor) (any, error) {
 	in := new(ExposePortRequest)
 	if err := dec(in); err != nil {
 		return nil, err
@@ -104,13 +104,13 @@ func _ControlService_ExposePort_Handler(srv interface{}, ctx context.Context, de
 		Server:     srv,
 		FullMethod: "/supervisor.ControlService/ExposePort",
 	}
-	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+	handler := func(ctx context.Context, req any) (any, error) {
 		return srv.(ControlServiceServer).ExposePort(ctx, req.(*ExposePortRequest))
 	}
 	return interceptor(ctx, in, info, handler)
 }
 
-func _ControlService_CreateSSHKeyPair_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+func _ControlService_CreateSSHKeyPair_Handler(srv any, ctx context.Context, dec func(any) error, interceptor grpc.UnaryServerInterceptor) (any, error) {
 	in := new(CreateSSHKeyPairRequest)
 	if err := dec(in); err != nil {
 		return nil, err
@@ -122,7 +122,7 @@ func _ControlService_CreateSSHKeyPair_Handler(srv interface{}, ctx context.Conte
 		Server:     srv,
 		FullMethod: "/supervisor.ControlService/CreateSSHKeyPair",
 	}
-	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+	handler := func(ctx context.Context, req any) (any, error) {
 		return srv.(ControlServiceServer).CreateSSHKeyPair(ctx, req.(*CreateSSHKeyPairRequest))
 	}
 	return interceptor(ctx, in, info, handler)

--- a/components/supervisor-api/go/info.pb.go
+++ b/components/supervisor-api/go/info.pb.go
@@ -544,7 +544,7 @@ func file_info_proto_rawDescGZIP() []byte {
 }
 
 var file_info_proto_msgTypes = make([]protoimpl.MessageInfo, 5)
-var file_info_proto_goTypes = []interface{}{
+var file_info_proto_goTypes = []any{
 	(*WorkspaceInfoRequest)(nil),                 // 0: supervisor.WorkspaceInfoRequest
 	(*WorkspaceInfoResponse)(nil),                // 1: supervisor.WorkspaceInfoResponse
 	(*WorkspaceInfoResponse_GitpodAPI)(nil),      // 2: supervisor.WorkspaceInfoResponse.GitpodAPI
@@ -570,7 +570,7 @@ func file_info_proto_init() {
 		return
 	}
 	if !protoimpl.UnsafeEnabled {
-		file_info_proto_msgTypes[0].Exporter = func(v interface{}, i int) interface{} {
+		file_info_proto_msgTypes[0].Exporter = func(v any, i int) any {
 			switch v := v.(*WorkspaceInfoRequest); i {
 			case 0:
 				return &v.state
@@ -582,7 +582,7 @@ func file_info_proto_init() {
 				return nil
 			}
 		}
-		file_info_proto_msgTypes[1].Exporter = func(v interface{}, i int) interface{} {
+		file_info_proto_msgTypes[1].Exporter = func(v any, i int) any {
 			switch v := v.(*WorkspaceInfoResponse); i {
 			case 0:
 				return &v.state
@@ -594,7 +594,7 @@ func file_info_proto_init() {
 				return nil
 			}
 		}
-		file_info_proto_msgTypes[2].Exporter = func(v interface{}, i int) interface{} {
+		file_info_proto_msgTypes[2].Exporter = func(v any, i int) any {
 			switch v := v.(*WorkspaceInfoResponse_GitpodAPI); i {
 			case 0:
 				return &v.state
@@ -606,7 +606,7 @@ func file_info_proto_init() {
 				return nil
 			}
 		}
-		file_info_proto_msgTypes[3].Exporter = func(v interface{}, i int) interface{} {
+		file_info_proto_msgTypes[3].Exporter = func(v any, i int) any {
 			switch v := v.(*WorkspaceInfoResponse_Repository); i {
 			case 0:
 				return &v.state
@@ -618,7 +618,7 @@ func file_info_proto_init() {
 				return nil
 			}
 		}
-		file_info_proto_msgTypes[4].Exporter = func(v interface{}, i int) interface{} {
+		file_info_proto_msgTypes[4].Exporter = func(v any, i int) any {
 			switch v := v.(*WorkspaceInfoResponse_WorkspaceClass); i {
 			case 0:
 				return &v.state
@@ -631,7 +631,7 @@ func file_info_proto_init() {
 			}
 		}
 	}
-	file_info_proto_msgTypes[1].OneofWrappers = []interface{}{
+	file_info_proto_msgTypes[1].OneofWrappers = []any{
 		(*WorkspaceInfoResponse_WorkspaceLocationFile)(nil),
 		(*WorkspaceInfoResponse_WorkspaceLocationFolder)(nil),
 	}

--- a/components/supervisor-api/go/info_grpc.pb.go
+++ b/components/supervisor-api/go/info_grpc.pb.go
@@ -74,7 +74,7 @@ func RegisterInfoServiceServer(s grpc.ServiceRegistrar, srv InfoServiceServer) {
 	s.RegisterService(&InfoService_ServiceDesc, srv)
 }
 
-func _InfoService_WorkspaceInfo_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+func _InfoService_WorkspaceInfo_Handler(srv any, ctx context.Context, dec func(any) error, interceptor grpc.UnaryServerInterceptor) (any, error) {
 	in := new(WorkspaceInfoRequest)
 	if err := dec(in); err != nil {
 		return nil, err
@@ -86,7 +86,7 @@ func _InfoService_WorkspaceInfo_Handler(srv interface{}, ctx context.Context, de
 		Server:     srv,
 		FullMethod: "/supervisor.InfoService/WorkspaceInfo",
 	}
-	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+	handler := func(ctx context.Context, req any) (any, error) {
 		return srv.(InfoServiceServer).WorkspaceInfo(ctx, req.(*WorkspaceInfoRequest))
 	}
 	return interceptor(ctx, in, info, handler)

--- a/components/supervisor-api/go/notification.pb.go
+++ b/components/supervisor-api/go/notification.pb.go
@@ -933,7 +933,7 @@ func file_notification_proto_rawDescGZIP() []byte {
 
 var file_notification_proto_enumTypes = make([]protoimpl.EnumInfo, 1)
 var file_notification_proto_msgTypes = make([]protoimpl.MessageInfo, 14)
-var file_notification_proto_goTypes = []interface{}{
+var file_notification_proto_goTypes = []any{
 	(NotifyRequest_Level)(0),                // 0: supervisor.NotifyRequest.Level
 	(*NotifyRequest)(nil),                   // 1: supervisor.NotifyRequest
 	(*NotifyResponse)(nil),                  // 2: supervisor.NotifyResponse
@@ -983,7 +983,7 @@ func file_notification_proto_init() {
 		return
 	}
 	if !protoimpl.UnsafeEnabled {
-		file_notification_proto_msgTypes[0].Exporter = func(v interface{}, i int) interface{} {
+		file_notification_proto_msgTypes[0].Exporter = func(v any, i int) any {
 			switch v := v.(*NotifyRequest); i {
 			case 0:
 				return &v.state
@@ -995,7 +995,7 @@ func file_notification_proto_init() {
 				return nil
 			}
 		}
-		file_notification_proto_msgTypes[1].Exporter = func(v interface{}, i int) interface{} {
+		file_notification_proto_msgTypes[1].Exporter = func(v any, i int) any {
 			switch v := v.(*NotifyResponse); i {
 			case 0:
 				return &v.state
@@ -1007,7 +1007,7 @@ func file_notification_proto_init() {
 				return nil
 			}
 		}
-		file_notification_proto_msgTypes[2].Exporter = func(v interface{}, i int) interface{} {
+		file_notification_proto_msgTypes[2].Exporter = func(v any, i int) any {
 			switch v := v.(*SubscribeRequest); i {
 			case 0:
 				return &v.state
@@ -1019,7 +1019,7 @@ func file_notification_proto_init() {
 				return nil
 			}
 		}
-		file_notification_proto_msgTypes[3].Exporter = func(v interface{}, i int) interface{} {
+		file_notification_proto_msgTypes[3].Exporter = func(v any, i int) any {
 			switch v := v.(*SubscribeResponse); i {
 			case 0:
 				return &v.state
@@ -1031,7 +1031,7 @@ func file_notification_proto_init() {
 				return nil
 			}
 		}
-		file_notification_proto_msgTypes[4].Exporter = func(v interface{}, i int) interface{} {
+		file_notification_proto_msgTypes[4].Exporter = func(v any, i int) any {
 			switch v := v.(*RespondRequest); i {
 			case 0:
 				return &v.state
@@ -1043,7 +1043,7 @@ func file_notification_proto_init() {
 				return nil
 			}
 		}
-		file_notification_proto_msgTypes[5].Exporter = func(v interface{}, i int) interface{} {
+		file_notification_proto_msgTypes[5].Exporter = func(v any, i int) any {
 			switch v := v.(*RespondResponse); i {
 			case 0:
 				return &v.state
@@ -1055,7 +1055,7 @@ func file_notification_proto_init() {
 				return nil
 			}
 		}
-		file_notification_proto_msgTypes[6].Exporter = func(v interface{}, i int) interface{} {
+		file_notification_proto_msgTypes[6].Exporter = func(v any, i int) any {
 			switch v := v.(*NotifyActiveRequest); i {
 			case 0:
 				return &v.state
@@ -1067,7 +1067,7 @@ func file_notification_proto_init() {
 				return nil
 			}
 		}
-		file_notification_proto_msgTypes[7].Exporter = func(v interface{}, i int) interface{} {
+		file_notification_proto_msgTypes[7].Exporter = func(v any, i int) any {
 			switch v := v.(*NotifyActiveResponse); i {
 			case 0:
 				return &v.state
@@ -1079,7 +1079,7 @@ func file_notification_proto_init() {
 				return nil
 			}
 		}
-		file_notification_proto_msgTypes[8].Exporter = func(v interface{}, i int) interface{} {
+		file_notification_proto_msgTypes[8].Exporter = func(v any, i int) any {
 			switch v := v.(*SubscribeActiveRequest); i {
 			case 0:
 				return &v.state
@@ -1091,7 +1091,7 @@ func file_notification_proto_init() {
 				return nil
 			}
 		}
-		file_notification_proto_msgTypes[9].Exporter = func(v interface{}, i int) interface{} {
+		file_notification_proto_msgTypes[9].Exporter = func(v any, i int) any {
 			switch v := v.(*SubscribeActiveResponse); i {
 			case 0:
 				return &v.state
@@ -1103,7 +1103,7 @@ func file_notification_proto_init() {
 				return nil
 			}
 		}
-		file_notification_proto_msgTypes[10].Exporter = func(v interface{}, i int) interface{} {
+		file_notification_proto_msgTypes[10].Exporter = func(v any, i int) any {
 			switch v := v.(*NotifyActiveRespondRequest); i {
 			case 0:
 				return &v.state
@@ -1115,7 +1115,7 @@ func file_notification_proto_init() {
 				return nil
 			}
 		}
-		file_notification_proto_msgTypes[11].Exporter = func(v interface{}, i int) interface{} {
+		file_notification_proto_msgTypes[11].Exporter = func(v any, i int) any {
 			switch v := v.(*NotifyActiveRespondResponse); i {
 			case 0:
 				return &v.state
@@ -1127,7 +1127,7 @@ func file_notification_proto_init() {
 				return nil
 			}
 		}
-		file_notification_proto_msgTypes[12].Exporter = func(v interface{}, i int) interface{} {
+		file_notification_proto_msgTypes[12].Exporter = func(v any, i int) any {
 			switch v := v.(*NotifyActiveRequest_OpenData); i {
 			case 0:
 				return &v.state
@@ -1139,7 +1139,7 @@ func file_notification_proto_init() {
 				return nil
 			}
 		}
-		file_notification_proto_msgTypes[13].Exporter = func(v interface{}, i int) interface{} {
+		file_notification_proto_msgTypes[13].Exporter = func(v any, i int) any {
 			switch v := v.(*NotifyActiveRequest_PreviewData); i {
 			case 0:
 				return &v.state
@@ -1152,7 +1152,7 @@ func file_notification_proto_init() {
 			}
 		}
 	}
-	file_notification_proto_msgTypes[6].OneofWrappers = []interface{}{
+	file_notification_proto_msgTypes[6].OneofWrappers = []any{
 		(*NotifyActiveRequest_Open)(nil),
 		(*NotifyActiveRequest_Preview)(nil),
 	}

--- a/components/supervisor-api/go/notification_grpc.pb.go
+++ b/components/supervisor-api/go/notification_grpc.pb.go
@@ -222,7 +222,7 @@ func RegisterNotificationServiceServer(s grpc.ServiceRegistrar, srv Notification
 	s.RegisterService(&NotificationService_ServiceDesc, srv)
 }
 
-func _NotificationService_Notify_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+func _NotificationService_Notify_Handler(srv any, ctx context.Context, dec func(any) error, interceptor grpc.UnaryServerInterceptor) (any, error) {
 	in := new(NotifyRequest)
 	if err := dec(in); err != nil {
 		return nil, err
@@ -234,13 +234,13 @@ func _NotificationService_Notify_Handler(srv interface{}, ctx context.Context, d
 		Server:     srv,
 		FullMethod: "/supervisor.NotificationService/Notify",
 	}
-	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+	handler := func(ctx context.Context, req any) (any, error) {
 		return srv.(NotificationServiceServer).Notify(ctx, req.(*NotifyRequest))
 	}
 	return interceptor(ctx, in, info, handler)
 }
 
-func _NotificationService_Subscribe_Handler(srv interface{}, stream grpc.ServerStream) error {
+func _NotificationService_Subscribe_Handler(srv any, stream grpc.ServerStream) error {
 	m := new(SubscribeRequest)
 	if err := stream.RecvMsg(m); err != nil {
 		return err
@@ -261,7 +261,7 @@ func (x *notificationServiceSubscribeServer) Send(m *SubscribeResponse) error {
 	return x.ServerStream.SendMsg(m)
 }
 
-func _NotificationService_Respond_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+func _NotificationService_Respond_Handler(srv any, ctx context.Context, dec func(any) error, interceptor grpc.UnaryServerInterceptor) (any, error) {
 	in := new(RespondRequest)
 	if err := dec(in); err != nil {
 		return nil, err
@@ -273,13 +273,13 @@ func _NotificationService_Respond_Handler(srv interface{}, ctx context.Context, 
 		Server:     srv,
 		FullMethod: "/supervisor.NotificationService/Respond",
 	}
-	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+	handler := func(ctx context.Context, req any) (any, error) {
 		return srv.(NotificationServiceServer).Respond(ctx, req.(*RespondRequest))
 	}
 	return interceptor(ctx, in, info, handler)
 }
 
-func _NotificationService_SubscribeActive_Handler(srv interface{}, stream grpc.ServerStream) error {
+func _NotificationService_SubscribeActive_Handler(srv any, stream grpc.ServerStream) error {
 	m := new(SubscribeActiveRequest)
 	if err := stream.RecvMsg(m); err != nil {
 		return err
@@ -300,7 +300,7 @@ func (x *notificationServiceSubscribeActiveServer) Send(m *SubscribeActiveRespon
 	return x.ServerStream.SendMsg(m)
 }
 
-func _NotificationService_NotifyActive_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+func _NotificationService_NotifyActive_Handler(srv any, ctx context.Context, dec func(any) error, interceptor grpc.UnaryServerInterceptor) (any, error) {
 	in := new(NotifyActiveRequest)
 	if err := dec(in); err != nil {
 		return nil, err
@@ -312,13 +312,13 @@ func _NotificationService_NotifyActive_Handler(srv interface{}, ctx context.Cont
 		Server:     srv,
 		FullMethod: "/supervisor.NotificationService/NotifyActive",
 	}
-	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+	handler := func(ctx context.Context, req any) (any, error) {
 		return srv.(NotificationServiceServer).NotifyActive(ctx, req.(*NotifyActiveRequest))
 	}
 	return interceptor(ctx, in, info, handler)
 }
 
-func _NotificationService_NotifyActiveRespond_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+func _NotificationService_NotifyActiveRespond_Handler(srv any, ctx context.Context, dec func(any) error, interceptor grpc.UnaryServerInterceptor) (any, error) {
 	in := new(NotifyActiveRespondRequest)
 	if err := dec(in); err != nil {
 		return nil, err
@@ -330,7 +330,7 @@ func _NotificationService_NotifyActiveRespond_Handler(srv interface{}, ctx conte
 		Server:     srv,
 		FullMethod: "/supervisor.NotificationService/NotifyActiveRespond",
 	}
-	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+	handler := func(ctx context.Context, req any) (any, error) {
 		return srv.(NotificationServiceServer).NotifyActiveRespond(ctx, req.(*NotifyActiveRespondRequest))
 	}
 	return interceptor(ctx, in, info, handler)

--- a/components/supervisor-api/go/port.pb.go
+++ b/components/supervisor-api/go/port.pb.go
@@ -668,7 +668,7 @@ func file_port_proto_rawDescGZIP() []byte {
 
 var file_port_proto_enumTypes = make([]protoimpl.EnumInfo, 1)
 var file_port_proto_msgTypes = make([]protoimpl.MessageInfo, 10)
-var file_port_proto_goTypes = []interface{}{
+var file_port_proto_goTypes = []any{
 	(TunnelVisiblity)(0),            // 0: supervisor.TunnelVisiblity
 	(*TunnelPortRequest)(nil),       // 1: supervisor.TunnelPortRequest
 	(*TunnelPortResponse)(nil),      // 2: supervisor.TunnelPortResponse
@@ -707,7 +707,7 @@ func file_port_proto_init() {
 		return
 	}
 	if !protoimpl.UnsafeEnabled {
-		file_port_proto_msgTypes[0].Exporter = func(v interface{}, i int) interface{} {
+		file_port_proto_msgTypes[0].Exporter = func(v any, i int) any {
 			switch v := v.(*TunnelPortRequest); i {
 			case 0:
 				return &v.state
@@ -719,7 +719,7 @@ func file_port_proto_init() {
 				return nil
 			}
 		}
-		file_port_proto_msgTypes[1].Exporter = func(v interface{}, i int) interface{} {
+		file_port_proto_msgTypes[1].Exporter = func(v any, i int) any {
 			switch v := v.(*TunnelPortResponse); i {
 			case 0:
 				return &v.state
@@ -731,7 +731,7 @@ func file_port_proto_init() {
 				return nil
 			}
 		}
-		file_port_proto_msgTypes[2].Exporter = func(v interface{}, i int) interface{} {
+		file_port_proto_msgTypes[2].Exporter = func(v any, i int) any {
 			switch v := v.(*CloseTunnelRequest); i {
 			case 0:
 				return &v.state
@@ -743,7 +743,7 @@ func file_port_proto_init() {
 				return nil
 			}
 		}
-		file_port_proto_msgTypes[3].Exporter = func(v interface{}, i int) interface{} {
+		file_port_proto_msgTypes[3].Exporter = func(v any, i int) any {
 			switch v := v.(*CloseTunnelResponse); i {
 			case 0:
 				return &v.state
@@ -755,7 +755,7 @@ func file_port_proto_init() {
 				return nil
 			}
 		}
-		file_port_proto_msgTypes[4].Exporter = func(v interface{}, i int) interface{} {
+		file_port_proto_msgTypes[4].Exporter = func(v any, i int) any {
 			switch v := v.(*EstablishTunnelRequest); i {
 			case 0:
 				return &v.state
@@ -767,7 +767,7 @@ func file_port_proto_init() {
 				return nil
 			}
 		}
-		file_port_proto_msgTypes[5].Exporter = func(v interface{}, i int) interface{} {
+		file_port_proto_msgTypes[5].Exporter = func(v any, i int) any {
 			switch v := v.(*EstablishTunnelResponse); i {
 			case 0:
 				return &v.state
@@ -779,7 +779,7 @@ func file_port_proto_init() {
 				return nil
 			}
 		}
-		file_port_proto_msgTypes[6].Exporter = func(v interface{}, i int) interface{} {
+		file_port_proto_msgTypes[6].Exporter = func(v any, i int) any {
 			switch v := v.(*AutoTunnelRequest); i {
 			case 0:
 				return &v.state
@@ -791,7 +791,7 @@ func file_port_proto_init() {
 				return nil
 			}
 		}
-		file_port_proto_msgTypes[7].Exporter = func(v interface{}, i int) interface{} {
+		file_port_proto_msgTypes[7].Exporter = func(v any, i int) any {
 			switch v := v.(*AutoTunnelResponse); i {
 			case 0:
 				return &v.state
@@ -803,7 +803,7 @@ func file_port_proto_init() {
 				return nil
 			}
 		}
-		file_port_proto_msgTypes[8].Exporter = func(v interface{}, i int) interface{} {
+		file_port_proto_msgTypes[8].Exporter = func(v any, i int) any {
 			switch v := v.(*RetryAutoExposeRequest); i {
 			case 0:
 				return &v.state
@@ -815,7 +815,7 @@ func file_port_proto_init() {
 				return nil
 			}
 		}
-		file_port_proto_msgTypes[9].Exporter = func(v interface{}, i int) interface{} {
+		file_port_proto_msgTypes[9].Exporter = func(v any, i int) any {
 			switch v := v.(*RetryAutoExposeResponse); i {
 			case 0:
 				return &v.state
@@ -828,7 +828,7 @@ func file_port_proto_init() {
 			}
 		}
 	}
-	file_port_proto_msgTypes[4].OneofWrappers = []interface{}{
+	file_port_proto_msgTypes[4].OneofWrappers = []any{
 		(*EstablishTunnelRequest_Desc)(nil),
 		(*EstablishTunnelRequest_Data)(nil),
 	}

--- a/components/supervisor-api/go/port_grpc.pb.go
+++ b/components/supervisor-api/go/port_grpc.pb.go
@@ -164,7 +164,7 @@ func RegisterPortServiceServer(s grpc.ServiceRegistrar, srv PortServiceServer) {
 	s.RegisterService(&PortService_ServiceDesc, srv)
 }
 
-func _PortService_Tunnel_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+func _PortService_Tunnel_Handler(srv any, ctx context.Context, dec func(any) error, interceptor grpc.UnaryServerInterceptor) (any, error) {
 	in := new(TunnelPortRequest)
 	if err := dec(in); err != nil {
 		return nil, err
@@ -176,13 +176,13 @@ func _PortService_Tunnel_Handler(srv interface{}, ctx context.Context, dec func(
 		Server:     srv,
 		FullMethod: "/supervisor.PortService/Tunnel",
 	}
-	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+	handler := func(ctx context.Context, req any) (any, error) {
 		return srv.(PortServiceServer).Tunnel(ctx, req.(*TunnelPortRequest))
 	}
 	return interceptor(ctx, in, info, handler)
 }
 
-func _PortService_CloseTunnel_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+func _PortService_CloseTunnel_Handler(srv any, ctx context.Context, dec func(any) error, interceptor grpc.UnaryServerInterceptor) (any, error) {
 	in := new(CloseTunnelRequest)
 	if err := dec(in); err != nil {
 		return nil, err
@@ -194,13 +194,13 @@ func _PortService_CloseTunnel_Handler(srv interface{}, ctx context.Context, dec 
 		Server:     srv,
 		FullMethod: "/supervisor.PortService/CloseTunnel",
 	}
-	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+	handler := func(ctx context.Context, req any) (any, error) {
 		return srv.(PortServiceServer).CloseTunnel(ctx, req.(*CloseTunnelRequest))
 	}
 	return interceptor(ctx, in, info, handler)
 }
 
-func _PortService_EstablishTunnel_Handler(srv interface{}, stream grpc.ServerStream) error {
+func _PortService_EstablishTunnel_Handler(srv any, stream grpc.ServerStream) error {
 	return srv.(PortServiceServer).EstablishTunnel(&portServiceEstablishTunnelServer{stream})
 }
 
@@ -226,7 +226,7 @@ func (x *portServiceEstablishTunnelServer) Recv() (*EstablishTunnelRequest, erro
 	return m, nil
 }
 
-func _PortService_AutoTunnel_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+func _PortService_AutoTunnel_Handler(srv any, ctx context.Context, dec func(any) error, interceptor grpc.UnaryServerInterceptor) (any, error) {
 	in := new(AutoTunnelRequest)
 	if err := dec(in); err != nil {
 		return nil, err
@@ -238,13 +238,13 @@ func _PortService_AutoTunnel_Handler(srv interface{}, ctx context.Context, dec f
 		Server:     srv,
 		FullMethod: "/supervisor.PortService/AutoTunnel",
 	}
-	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+	handler := func(ctx context.Context, req any) (any, error) {
 		return srv.(PortServiceServer).AutoTunnel(ctx, req.(*AutoTunnelRequest))
 	}
 	return interceptor(ctx, in, info, handler)
 }
 
-func _PortService_RetryAutoExpose_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+func _PortService_RetryAutoExpose_Handler(srv any, ctx context.Context, dec func(any) error, interceptor grpc.UnaryServerInterceptor) (any, error) {
 	in := new(RetryAutoExposeRequest)
 	if err := dec(in); err != nil {
 		return nil, err
@@ -256,7 +256,7 @@ func _PortService_RetryAutoExpose_Handler(srv interface{}, ctx context.Context, 
 		Server:     srv,
 		FullMethod: "/supervisor.PortService/RetryAutoExpose",
 	}
-	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+	handler := func(ctx context.Context, req any) (any, error) {
 		return srv.(PortServiceServer).RetryAutoExpose(ctx, req.(*RetryAutoExposeRequest))
 	}
 	return interceptor(ctx, in, info, handler)

--- a/components/supervisor-api/go/status.pb.go
+++ b/components/supervisor-api/go/status.pb.go
@@ -1740,7 +1740,7 @@ func file_status_proto_rawDescGZIP() []byte {
 
 var file_status_proto_enumTypes = make([]protoimpl.EnumInfo, 6)
 var file_status_proto_msgTypes = make([]protoimpl.MessageInfo, 22)
-var file_status_proto_goTypes = []interface{}{
+var file_status_proto_goTypes = []any{
 	(ContentSource)(0),                      // 0: supervisor.ContentSource
 	(PortVisibility)(0),                     // 1: supervisor.PortVisibility
 	(OnPortExposedAction)(0),                // 2: supervisor.OnPortExposedAction
@@ -1816,7 +1816,7 @@ func file_status_proto_init() {
 	}
 	file_port_proto_init()
 	if !protoimpl.UnsafeEnabled {
-		file_status_proto_msgTypes[0].Exporter = func(v interface{}, i int) interface{} {
+		file_status_proto_msgTypes[0].Exporter = func(v any, i int) any {
 			switch v := v.(*SupervisorStatusRequest); i {
 			case 0:
 				return &v.state
@@ -1828,7 +1828,7 @@ func file_status_proto_init() {
 				return nil
 			}
 		}
-		file_status_proto_msgTypes[1].Exporter = func(v interface{}, i int) interface{} {
+		file_status_proto_msgTypes[1].Exporter = func(v any, i int) any {
 			switch v := v.(*SupervisorStatusResponse); i {
 			case 0:
 				return &v.state
@@ -1840,7 +1840,7 @@ func file_status_proto_init() {
 				return nil
 			}
 		}
-		file_status_proto_msgTypes[2].Exporter = func(v interface{}, i int) interface{} {
+		file_status_proto_msgTypes[2].Exporter = func(v any, i int) any {
 			switch v := v.(*IDEStatusRequest); i {
 			case 0:
 				return &v.state
@@ -1852,7 +1852,7 @@ func file_status_proto_init() {
 				return nil
 			}
 		}
-		file_status_proto_msgTypes[3].Exporter = func(v interface{}, i int) interface{} {
+		file_status_proto_msgTypes[3].Exporter = func(v any, i int) any {
 			switch v := v.(*IDEStatusResponse); i {
 			case 0:
 				return &v.state
@@ -1864,7 +1864,7 @@ func file_status_proto_init() {
 				return nil
 			}
 		}
-		file_status_proto_msgTypes[4].Exporter = func(v interface{}, i int) interface{} {
+		file_status_proto_msgTypes[4].Exporter = func(v any, i int) any {
 			switch v := v.(*ContentStatusRequest); i {
 			case 0:
 				return &v.state
@@ -1876,7 +1876,7 @@ func file_status_proto_init() {
 				return nil
 			}
 		}
-		file_status_proto_msgTypes[5].Exporter = func(v interface{}, i int) interface{} {
+		file_status_proto_msgTypes[5].Exporter = func(v any, i int) any {
 			switch v := v.(*ContentStatusResponse); i {
 			case 0:
 				return &v.state
@@ -1888,7 +1888,7 @@ func file_status_proto_init() {
 				return nil
 			}
 		}
-		file_status_proto_msgTypes[6].Exporter = func(v interface{}, i int) interface{} {
+		file_status_proto_msgTypes[6].Exporter = func(v any, i int) any {
 			switch v := v.(*BackupStatusRequest); i {
 			case 0:
 				return &v.state
@@ -1900,7 +1900,7 @@ func file_status_proto_init() {
 				return nil
 			}
 		}
-		file_status_proto_msgTypes[7].Exporter = func(v interface{}, i int) interface{} {
+		file_status_proto_msgTypes[7].Exporter = func(v any, i int) any {
 			switch v := v.(*BackupStatusResponse); i {
 			case 0:
 				return &v.state
@@ -1912,7 +1912,7 @@ func file_status_proto_init() {
 				return nil
 			}
 		}
-		file_status_proto_msgTypes[8].Exporter = func(v interface{}, i int) interface{} {
+		file_status_proto_msgTypes[8].Exporter = func(v any, i int) any {
 			switch v := v.(*PortsStatusRequest); i {
 			case 0:
 				return &v.state
@@ -1924,7 +1924,7 @@ func file_status_proto_init() {
 				return nil
 			}
 		}
-		file_status_proto_msgTypes[9].Exporter = func(v interface{}, i int) interface{} {
+		file_status_proto_msgTypes[9].Exporter = func(v any, i int) any {
 			switch v := v.(*PortsStatusResponse); i {
 			case 0:
 				return &v.state
@@ -1936,7 +1936,7 @@ func file_status_proto_init() {
 				return nil
 			}
 		}
-		file_status_proto_msgTypes[10].Exporter = func(v interface{}, i int) interface{} {
+		file_status_proto_msgTypes[10].Exporter = func(v any, i int) any {
 			switch v := v.(*ExposedPortInfo); i {
 			case 0:
 				return &v.state
@@ -1948,7 +1948,7 @@ func file_status_proto_init() {
 				return nil
 			}
 		}
-		file_status_proto_msgTypes[11].Exporter = func(v interface{}, i int) interface{} {
+		file_status_proto_msgTypes[11].Exporter = func(v any, i int) any {
 			switch v := v.(*TunneledPortInfo); i {
 			case 0:
 				return &v.state
@@ -1960,7 +1960,7 @@ func file_status_proto_init() {
 				return nil
 			}
 		}
-		file_status_proto_msgTypes[12].Exporter = func(v interface{}, i int) interface{} {
+		file_status_proto_msgTypes[12].Exporter = func(v any, i int) any {
 			switch v := v.(*PortsStatus); i {
 			case 0:
 				return &v.state
@@ -1972,7 +1972,7 @@ func file_status_proto_init() {
 				return nil
 			}
 		}
-		file_status_proto_msgTypes[13].Exporter = func(v interface{}, i int) interface{} {
+		file_status_proto_msgTypes[13].Exporter = func(v any, i int) any {
 			switch v := v.(*TasksStatusRequest); i {
 			case 0:
 				return &v.state
@@ -1984,7 +1984,7 @@ func file_status_proto_init() {
 				return nil
 			}
 		}
-		file_status_proto_msgTypes[14].Exporter = func(v interface{}, i int) interface{} {
+		file_status_proto_msgTypes[14].Exporter = func(v any, i int) any {
 			switch v := v.(*TasksStatusResponse); i {
 			case 0:
 				return &v.state
@@ -1996,7 +1996,7 @@ func file_status_proto_init() {
 				return nil
 			}
 		}
-		file_status_proto_msgTypes[15].Exporter = func(v interface{}, i int) interface{} {
+		file_status_proto_msgTypes[15].Exporter = func(v any, i int) any {
 			switch v := v.(*TaskStatus); i {
 			case 0:
 				return &v.state
@@ -2008,7 +2008,7 @@ func file_status_proto_init() {
 				return nil
 			}
 		}
-		file_status_proto_msgTypes[16].Exporter = func(v interface{}, i int) interface{} {
+		file_status_proto_msgTypes[16].Exporter = func(v any, i int) any {
 			switch v := v.(*TaskPresentation); i {
 			case 0:
 				return &v.state
@@ -2020,7 +2020,7 @@ func file_status_proto_init() {
 				return nil
 			}
 		}
-		file_status_proto_msgTypes[17].Exporter = func(v interface{}, i int) interface{} {
+		file_status_proto_msgTypes[17].Exporter = func(v any, i int) any {
 			switch v := v.(*ResourcesStatuRequest); i {
 			case 0:
 				return &v.state
@@ -2032,7 +2032,7 @@ func file_status_proto_init() {
 				return nil
 			}
 		}
-		file_status_proto_msgTypes[18].Exporter = func(v interface{}, i int) interface{} {
+		file_status_proto_msgTypes[18].Exporter = func(v any, i int) any {
 			switch v := v.(*ResourcesStatusResponse); i {
 			case 0:
 				return &v.state
@@ -2044,7 +2044,7 @@ func file_status_proto_init() {
 				return nil
 			}
 		}
-		file_status_proto_msgTypes[19].Exporter = func(v interface{}, i int) interface{} {
+		file_status_proto_msgTypes[19].Exporter = func(v any, i int) any {
 			switch v := v.(*ResourceStatus); i {
 			case 0:
 				return &v.state
@@ -2056,7 +2056,7 @@ func file_status_proto_init() {
 				return nil
 			}
 		}
-		file_status_proto_msgTypes[20].Exporter = func(v interface{}, i int) interface{} {
+		file_status_proto_msgTypes[20].Exporter = func(v any, i int) any {
 			switch v := v.(*IDEStatusResponse_DesktopStatus); i {
 			case 0:
 				return &v.state

--- a/components/supervisor-api/go/status_grpc.pb.go
+++ b/components/supervisor-api/go/status_grpc.pb.go
@@ -224,7 +224,7 @@ func RegisterStatusServiceServer(s grpc.ServiceRegistrar, srv StatusServiceServe
 	s.RegisterService(&StatusService_ServiceDesc, srv)
 }
 
-func _StatusService_SupervisorStatus_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+func _StatusService_SupervisorStatus_Handler(srv any, ctx context.Context, dec func(any) error, interceptor grpc.UnaryServerInterceptor) (any, error) {
 	in := new(SupervisorStatusRequest)
 	if err := dec(in); err != nil {
 		return nil, err
@@ -236,13 +236,13 @@ func _StatusService_SupervisorStatus_Handler(srv interface{}, ctx context.Contex
 		Server:     srv,
 		FullMethod: "/supervisor.StatusService/SupervisorStatus",
 	}
-	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+	handler := func(ctx context.Context, req any) (any, error) {
 		return srv.(StatusServiceServer).SupervisorStatus(ctx, req.(*SupervisorStatusRequest))
 	}
 	return interceptor(ctx, in, info, handler)
 }
 
-func _StatusService_IDEStatus_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+func _StatusService_IDEStatus_Handler(srv any, ctx context.Context, dec func(any) error, interceptor grpc.UnaryServerInterceptor) (any, error) {
 	in := new(IDEStatusRequest)
 	if err := dec(in); err != nil {
 		return nil, err
@@ -254,13 +254,13 @@ func _StatusService_IDEStatus_Handler(srv interface{}, ctx context.Context, dec 
 		Server:     srv,
 		FullMethod: "/supervisor.StatusService/IDEStatus",
 	}
-	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+	handler := func(ctx context.Context, req any) (any, error) {
 		return srv.(StatusServiceServer).IDEStatus(ctx, req.(*IDEStatusRequest))
 	}
 	return interceptor(ctx, in, info, handler)
 }
 
-func _StatusService_ContentStatus_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+func _StatusService_ContentStatus_Handler(srv any, ctx context.Context, dec func(any) error, interceptor grpc.UnaryServerInterceptor) (any, error) {
 	in := new(ContentStatusRequest)
 	if err := dec(in); err != nil {
 		return nil, err
@@ -272,13 +272,13 @@ func _StatusService_ContentStatus_Handler(srv interface{}, ctx context.Context, 
 		Server:     srv,
 		FullMethod: "/supervisor.StatusService/ContentStatus",
 	}
-	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+	handler := func(ctx context.Context, req any) (any, error) {
 		return srv.(StatusServiceServer).ContentStatus(ctx, req.(*ContentStatusRequest))
 	}
 	return interceptor(ctx, in, info, handler)
 }
 
-func _StatusService_BackupStatus_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+func _StatusService_BackupStatus_Handler(srv any, ctx context.Context, dec func(any) error, interceptor grpc.UnaryServerInterceptor) (any, error) {
 	in := new(BackupStatusRequest)
 	if err := dec(in); err != nil {
 		return nil, err
@@ -290,13 +290,13 @@ func _StatusService_BackupStatus_Handler(srv interface{}, ctx context.Context, d
 		Server:     srv,
 		FullMethod: "/supervisor.StatusService/BackupStatus",
 	}
-	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+	handler := func(ctx context.Context, req any) (any, error) {
 		return srv.(StatusServiceServer).BackupStatus(ctx, req.(*BackupStatusRequest))
 	}
 	return interceptor(ctx, in, info, handler)
 }
 
-func _StatusService_PortsStatus_Handler(srv interface{}, stream grpc.ServerStream) error {
+func _StatusService_PortsStatus_Handler(srv any, stream grpc.ServerStream) error {
 	m := new(PortsStatusRequest)
 	if err := stream.RecvMsg(m); err != nil {
 		return err
@@ -317,7 +317,7 @@ func (x *statusServicePortsStatusServer) Send(m *PortsStatusResponse) error {
 	return x.ServerStream.SendMsg(m)
 }
 
-func _StatusService_TasksStatus_Handler(srv interface{}, stream grpc.ServerStream) error {
+func _StatusService_TasksStatus_Handler(srv any, stream grpc.ServerStream) error {
 	m := new(TasksStatusRequest)
 	if err := stream.RecvMsg(m); err != nil {
 		return err
@@ -338,7 +338,7 @@ func (x *statusServiceTasksStatusServer) Send(m *TasksStatusResponse) error {
 	return x.ServerStream.SendMsg(m)
 }
 
-func _StatusService_ResourcesStatus_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+func _StatusService_ResourcesStatus_Handler(srv any, ctx context.Context, dec func(any) error, interceptor grpc.UnaryServerInterceptor) (any, error) {
 	in := new(ResourcesStatuRequest)
 	if err := dec(in); err != nil {
 		return nil, err
@@ -350,7 +350,7 @@ func _StatusService_ResourcesStatus_Handler(srv interface{}, ctx context.Context
 		Server:     srv,
 		FullMethod: "/supervisor.StatusService/ResourcesStatus",
 	}
-	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+	handler := func(ctx context.Context, req any) (any, error) {
 		return srv.(StatusServiceServer).ResourcesStatus(ctx, req.(*ResourcesStatuRequest))
 	}
 	return interceptor(ctx, in, info, handler)

--- a/components/supervisor-api/go/terminal.pb.go
+++ b/components/supervisor-api/go/terminal.pb.go
@@ -1423,7 +1423,7 @@ func file_terminal_proto_rawDescGZIP() []byte {
 
 var file_terminal_proto_enumTypes = make([]protoimpl.EnumInfo, 1)
 var file_terminal_proto_msgTypes = make([]protoimpl.MessageInfo, 23)
-var file_terminal_proto_goTypes = []interface{}{
+var file_terminal_proto_goTypes = []any{
 	(TerminalTitleSource)(0),                  // 0: supervisor.TerminalTitleSource
 	(*TerminalSize)(nil),                      // 1: supervisor.TerminalSize
 	(*OpenTerminalRequest)(nil),               // 2: supervisor.OpenTerminalRequest
@@ -1491,7 +1491,7 @@ func file_terminal_proto_init() {
 		return
 	}
 	if !protoimpl.UnsafeEnabled {
-		file_terminal_proto_msgTypes[0].Exporter = func(v interface{}, i int) interface{} {
+		file_terminal_proto_msgTypes[0].Exporter = func(v any, i int) any {
 			switch v := v.(*TerminalSize); i {
 			case 0:
 				return &v.state
@@ -1503,7 +1503,7 @@ func file_terminal_proto_init() {
 				return nil
 			}
 		}
-		file_terminal_proto_msgTypes[1].Exporter = func(v interface{}, i int) interface{} {
+		file_terminal_proto_msgTypes[1].Exporter = func(v any, i int) any {
 			switch v := v.(*OpenTerminalRequest); i {
 			case 0:
 				return &v.state
@@ -1515,7 +1515,7 @@ func file_terminal_proto_init() {
 				return nil
 			}
 		}
-		file_terminal_proto_msgTypes[2].Exporter = func(v interface{}, i int) interface{} {
+		file_terminal_proto_msgTypes[2].Exporter = func(v any, i int) any {
 			switch v := v.(*OpenTerminalResponse); i {
 			case 0:
 				return &v.state
@@ -1527,7 +1527,7 @@ func file_terminal_proto_init() {
 				return nil
 			}
 		}
-		file_terminal_proto_msgTypes[3].Exporter = func(v interface{}, i int) interface{} {
+		file_terminal_proto_msgTypes[3].Exporter = func(v any, i int) any {
 			switch v := v.(*ShutdownTerminalRequest); i {
 			case 0:
 				return &v.state
@@ -1539,7 +1539,7 @@ func file_terminal_proto_init() {
 				return nil
 			}
 		}
-		file_terminal_proto_msgTypes[4].Exporter = func(v interface{}, i int) interface{} {
+		file_terminal_proto_msgTypes[4].Exporter = func(v any, i int) any {
 			switch v := v.(*ShutdownTerminalResponse); i {
 			case 0:
 				return &v.state
@@ -1551,7 +1551,7 @@ func file_terminal_proto_init() {
 				return nil
 			}
 		}
-		file_terminal_proto_msgTypes[5].Exporter = func(v interface{}, i int) interface{} {
+		file_terminal_proto_msgTypes[5].Exporter = func(v any, i int) any {
 			switch v := v.(*Terminal); i {
 			case 0:
 				return &v.state
@@ -1563,7 +1563,7 @@ func file_terminal_proto_init() {
 				return nil
 			}
 		}
-		file_terminal_proto_msgTypes[6].Exporter = func(v interface{}, i int) interface{} {
+		file_terminal_proto_msgTypes[6].Exporter = func(v any, i int) any {
 			switch v := v.(*GetTerminalRequest); i {
 			case 0:
 				return &v.state
@@ -1575,7 +1575,7 @@ func file_terminal_proto_init() {
 				return nil
 			}
 		}
-		file_terminal_proto_msgTypes[7].Exporter = func(v interface{}, i int) interface{} {
+		file_terminal_proto_msgTypes[7].Exporter = func(v any, i int) any {
 			switch v := v.(*ListTerminalsRequest); i {
 			case 0:
 				return &v.state
@@ -1587,7 +1587,7 @@ func file_terminal_proto_init() {
 				return nil
 			}
 		}
-		file_terminal_proto_msgTypes[8].Exporter = func(v interface{}, i int) interface{} {
+		file_terminal_proto_msgTypes[8].Exporter = func(v any, i int) any {
 			switch v := v.(*ListTerminalsResponse); i {
 			case 0:
 				return &v.state
@@ -1599,7 +1599,7 @@ func file_terminal_proto_init() {
 				return nil
 			}
 		}
-		file_terminal_proto_msgTypes[9].Exporter = func(v interface{}, i int) interface{} {
+		file_terminal_proto_msgTypes[9].Exporter = func(v any, i int) any {
 			switch v := v.(*ListenTerminalRequest); i {
 			case 0:
 				return &v.state
@@ -1611,7 +1611,7 @@ func file_terminal_proto_init() {
 				return nil
 			}
 		}
-		file_terminal_proto_msgTypes[10].Exporter = func(v interface{}, i int) interface{} {
+		file_terminal_proto_msgTypes[10].Exporter = func(v any, i int) any {
 			switch v := v.(*ListenTerminalResponse); i {
 			case 0:
 				return &v.state
@@ -1623,7 +1623,7 @@ func file_terminal_proto_init() {
 				return nil
 			}
 		}
-		file_terminal_proto_msgTypes[11].Exporter = func(v interface{}, i int) interface{} {
+		file_terminal_proto_msgTypes[11].Exporter = func(v any, i int) any {
 			switch v := v.(*WriteTerminalRequest); i {
 			case 0:
 				return &v.state
@@ -1635,7 +1635,7 @@ func file_terminal_proto_init() {
 				return nil
 			}
 		}
-		file_terminal_proto_msgTypes[12].Exporter = func(v interface{}, i int) interface{} {
+		file_terminal_proto_msgTypes[12].Exporter = func(v any, i int) any {
 			switch v := v.(*WriteTerminalResponse); i {
 			case 0:
 				return &v.state
@@ -1647,7 +1647,7 @@ func file_terminal_proto_init() {
 				return nil
 			}
 		}
-		file_terminal_proto_msgTypes[13].Exporter = func(v interface{}, i int) interface{} {
+		file_terminal_proto_msgTypes[13].Exporter = func(v any, i int) any {
 			switch v := v.(*SetTerminalSizeRequest); i {
 			case 0:
 				return &v.state
@@ -1659,7 +1659,7 @@ func file_terminal_proto_init() {
 				return nil
 			}
 		}
-		file_terminal_proto_msgTypes[14].Exporter = func(v interface{}, i int) interface{} {
+		file_terminal_proto_msgTypes[14].Exporter = func(v any, i int) any {
 			switch v := v.(*SetTerminalSizeResponse); i {
 			case 0:
 				return &v.state
@@ -1671,7 +1671,7 @@ func file_terminal_proto_init() {
 				return nil
 			}
 		}
-		file_terminal_proto_msgTypes[15].Exporter = func(v interface{}, i int) interface{} {
+		file_terminal_proto_msgTypes[15].Exporter = func(v any, i int) any {
 			switch v := v.(*SetTerminalTitleRequest); i {
 			case 0:
 				return &v.state
@@ -1683,7 +1683,7 @@ func file_terminal_proto_init() {
 				return nil
 			}
 		}
-		file_terminal_proto_msgTypes[16].Exporter = func(v interface{}, i int) interface{} {
+		file_terminal_proto_msgTypes[16].Exporter = func(v any, i int) any {
 			switch v := v.(*SetTerminalTitleResponse); i {
 			case 0:
 				return &v.state
@@ -1695,7 +1695,7 @@ func file_terminal_proto_init() {
 				return nil
 			}
 		}
-		file_terminal_proto_msgTypes[17].Exporter = func(v interface{}, i int) interface{} {
+		file_terminal_proto_msgTypes[17].Exporter = func(v any, i int) any {
 			switch v := v.(*UpdateTerminalAnnotationsRequest); i {
 			case 0:
 				return &v.state
@@ -1707,7 +1707,7 @@ func file_terminal_proto_init() {
 				return nil
 			}
 		}
-		file_terminal_proto_msgTypes[18].Exporter = func(v interface{}, i int) interface{} {
+		file_terminal_proto_msgTypes[18].Exporter = func(v any, i int) any {
 			switch v := v.(*UpdateTerminalAnnotationsResponse); i {
 			case 0:
 				return &v.state
@@ -1720,12 +1720,12 @@ func file_terminal_proto_init() {
 			}
 		}
 	}
-	file_terminal_proto_msgTypes[10].OneofWrappers = []interface{}{
+	file_terminal_proto_msgTypes[10].OneofWrappers = []any{
 		(*ListenTerminalResponse_Data)(nil),
 		(*ListenTerminalResponse_ExitCode)(nil),
 		(*ListenTerminalResponse_Title)(nil),
 	}
-	file_terminal_proto_msgTypes[13].OneofWrappers = []interface{}{
+	file_terminal_proto_msgTypes[13].OneofWrappers = []any{
 		(*SetTerminalSizeRequest_Token)(nil),
 		(*SetTerminalSizeRequest_Force)(nil),
 	}

--- a/components/supervisor-api/go/terminal_grpc.pb.go
+++ b/components/supervisor-api/go/terminal_grpc.pb.go
@@ -229,7 +229,7 @@ func RegisterTerminalServiceServer(s grpc.ServiceRegistrar, srv TerminalServiceS
 	s.RegisterService(&TerminalService_ServiceDesc, srv)
 }
 
-func _TerminalService_Open_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+func _TerminalService_Open_Handler(srv any, ctx context.Context, dec func(any) error, interceptor grpc.UnaryServerInterceptor) (any, error) {
 	in := new(OpenTerminalRequest)
 	if err := dec(in); err != nil {
 		return nil, err
@@ -241,13 +241,13 @@ func _TerminalService_Open_Handler(srv interface{}, ctx context.Context, dec fun
 		Server:     srv,
 		FullMethod: "/supervisor.TerminalService/Open",
 	}
-	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+	handler := func(ctx context.Context, req any) (any, error) {
 		return srv.(TerminalServiceServer).Open(ctx, req.(*OpenTerminalRequest))
 	}
 	return interceptor(ctx, in, info, handler)
 }
 
-func _TerminalService_Shutdown_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+func _TerminalService_Shutdown_Handler(srv any, ctx context.Context, dec func(any) error, interceptor grpc.UnaryServerInterceptor) (any, error) {
 	in := new(ShutdownTerminalRequest)
 	if err := dec(in); err != nil {
 		return nil, err
@@ -259,13 +259,13 @@ func _TerminalService_Shutdown_Handler(srv interface{}, ctx context.Context, dec
 		Server:     srv,
 		FullMethod: "/supervisor.TerminalService/Shutdown",
 	}
-	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+	handler := func(ctx context.Context, req any) (any, error) {
 		return srv.(TerminalServiceServer).Shutdown(ctx, req.(*ShutdownTerminalRequest))
 	}
 	return interceptor(ctx, in, info, handler)
 }
 
-func _TerminalService_Get_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+func _TerminalService_Get_Handler(srv any, ctx context.Context, dec func(any) error, interceptor grpc.UnaryServerInterceptor) (any, error) {
 	in := new(GetTerminalRequest)
 	if err := dec(in); err != nil {
 		return nil, err
@@ -277,13 +277,13 @@ func _TerminalService_Get_Handler(srv interface{}, ctx context.Context, dec func
 		Server:     srv,
 		FullMethod: "/supervisor.TerminalService/Get",
 	}
-	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+	handler := func(ctx context.Context, req any) (any, error) {
 		return srv.(TerminalServiceServer).Get(ctx, req.(*GetTerminalRequest))
 	}
 	return interceptor(ctx, in, info, handler)
 }
 
-func _TerminalService_List_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+func _TerminalService_List_Handler(srv any, ctx context.Context, dec func(any) error, interceptor grpc.UnaryServerInterceptor) (any, error) {
 	in := new(ListTerminalsRequest)
 	if err := dec(in); err != nil {
 		return nil, err
@@ -295,13 +295,13 @@ func _TerminalService_List_Handler(srv interface{}, ctx context.Context, dec fun
 		Server:     srv,
 		FullMethod: "/supervisor.TerminalService/List",
 	}
-	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+	handler := func(ctx context.Context, req any) (any, error) {
 		return srv.(TerminalServiceServer).List(ctx, req.(*ListTerminalsRequest))
 	}
 	return interceptor(ctx, in, info, handler)
 }
 
-func _TerminalService_Listen_Handler(srv interface{}, stream grpc.ServerStream) error {
+func _TerminalService_Listen_Handler(srv any, stream grpc.ServerStream) error {
 	m := new(ListenTerminalRequest)
 	if err := stream.RecvMsg(m); err != nil {
 		return err
@@ -322,7 +322,7 @@ func (x *terminalServiceListenServer) Send(m *ListenTerminalResponse) error {
 	return x.ServerStream.SendMsg(m)
 }
 
-func _TerminalService_Write_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+func _TerminalService_Write_Handler(srv any, ctx context.Context, dec func(any) error, interceptor grpc.UnaryServerInterceptor) (any, error) {
 	in := new(WriteTerminalRequest)
 	if err := dec(in); err != nil {
 		return nil, err
@@ -334,13 +334,13 @@ func _TerminalService_Write_Handler(srv interface{}, ctx context.Context, dec fu
 		Server:     srv,
 		FullMethod: "/supervisor.TerminalService/Write",
 	}
-	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+	handler := func(ctx context.Context, req any) (any, error) {
 		return srv.(TerminalServiceServer).Write(ctx, req.(*WriteTerminalRequest))
 	}
 	return interceptor(ctx, in, info, handler)
 }
 
-func _TerminalService_SetSize_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+func _TerminalService_SetSize_Handler(srv any, ctx context.Context, dec func(any) error, interceptor grpc.UnaryServerInterceptor) (any, error) {
 	in := new(SetTerminalSizeRequest)
 	if err := dec(in); err != nil {
 		return nil, err
@@ -352,13 +352,13 @@ func _TerminalService_SetSize_Handler(srv interface{}, ctx context.Context, dec 
 		Server:     srv,
 		FullMethod: "/supervisor.TerminalService/SetSize",
 	}
-	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+	handler := func(ctx context.Context, req any) (any, error) {
 		return srv.(TerminalServiceServer).SetSize(ctx, req.(*SetTerminalSizeRequest))
 	}
 	return interceptor(ctx, in, info, handler)
 }
 
-func _TerminalService_SetTitle_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+func _TerminalService_SetTitle_Handler(srv any, ctx context.Context, dec func(any) error, interceptor grpc.UnaryServerInterceptor) (any, error) {
 	in := new(SetTerminalTitleRequest)
 	if err := dec(in); err != nil {
 		return nil, err
@@ -370,13 +370,13 @@ func _TerminalService_SetTitle_Handler(srv interface{}, ctx context.Context, dec
 		Server:     srv,
 		FullMethod: "/supervisor.TerminalService/SetTitle",
 	}
-	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+	handler := func(ctx context.Context, req any) (any, error) {
 		return srv.(TerminalServiceServer).SetTitle(ctx, req.(*SetTerminalTitleRequest))
 	}
 	return interceptor(ctx, in, info, handler)
 }
 
-func _TerminalService_UpdateAnnotations_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+func _TerminalService_UpdateAnnotations_Handler(srv any, ctx context.Context, dec func(any) error, interceptor grpc.UnaryServerInterceptor) (any, error) {
 	in := new(UpdateTerminalAnnotationsRequest)
 	if err := dec(in); err != nil {
 		return nil, err
@@ -388,7 +388,7 @@ func _TerminalService_UpdateAnnotations_Handler(srv interface{}, ctx context.Con
 		Server:     srv,
 		FullMethod: "/supervisor.TerminalService/UpdateAnnotations",
 	}
-	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+	handler := func(ctx context.Context, req any) (any, error) {
 		return srv.(TerminalServiceServer).UpdateAnnotations(ctx, req.(*UpdateTerminalAnnotationsRequest))
 	}
 	return interceptor(ctx, in, info, handler)

--- a/components/supervisor-api/go/token.pb.go
+++ b/components/supervisor-api/go/token.pb.go
@@ -760,7 +760,7 @@ func file_token_proto_rawDescGZIP() []byte {
 
 var file_token_proto_enumTypes = make([]protoimpl.EnumInfo, 1)
 var file_token_proto_msgTypes = make([]protoimpl.MessageInfo, 9)
-var file_token_proto_goTypes = []interface{}{
+var file_token_proto_goTypes = []any{
 	(TokenReuse)(0),                              // 0: supervisor.TokenReuse
 	(*GetTokenRequest)(nil),                      // 1: supervisor.GetTokenRequest
 	(*GetTokenResponse)(nil),                     // 2: supervisor.GetTokenResponse
@@ -800,7 +800,7 @@ func file_token_proto_init() {
 		return
 	}
 	if !protoimpl.UnsafeEnabled {
-		file_token_proto_msgTypes[0].Exporter = func(v interface{}, i int) interface{} {
+		file_token_proto_msgTypes[0].Exporter = func(v any, i int) any {
 			switch v := v.(*GetTokenRequest); i {
 			case 0:
 				return &v.state
@@ -812,7 +812,7 @@ func file_token_proto_init() {
 				return nil
 			}
 		}
-		file_token_proto_msgTypes[1].Exporter = func(v interface{}, i int) interface{} {
+		file_token_proto_msgTypes[1].Exporter = func(v any, i int) any {
 			switch v := v.(*GetTokenResponse); i {
 			case 0:
 				return &v.state
@@ -824,7 +824,7 @@ func file_token_proto_init() {
 				return nil
 			}
 		}
-		file_token_proto_msgTypes[2].Exporter = func(v interface{}, i int) interface{} {
+		file_token_proto_msgTypes[2].Exporter = func(v any, i int) any {
 			switch v := v.(*SetTokenRequest); i {
 			case 0:
 				return &v.state
@@ -836,7 +836,7 @@ func file_token_proto_init() {
 				return nil
 			}
 		}
-		file_token_proto_msgTypes[3].Exporter = func(v interface{}, i int) interface{} {
+		file_token_proto_msgTypes[3].Exporter = func(v any, i int) any {
 			switch v := v.(*SetTokenResponse); i {
 			case 0:
 				return &v.state
@@ -848,7 +848,7 @@ func file_token_proto_init() {
 				return nil
 			}
 		}
-		file_token_proto_msgTypes[4].Exporter = func(v interface{}, i int) interface{} {
+		file_token_proto_msgTypes[4].Exporter = func(v any, i int) any {
 			switch v := v.(*ClearTokenRequest); i {
 			case 0:
 				return &v.state
@@ -860,7 +860,7 @@ func file_token_proto_init() {
 				return nil
 			}
 		}
-		file_token_proto_msgTypes[5].Exporter = func(v interface{}, i int) interface{} {
+		file_token_proto_msgTypes[5].Exporter = func(v any, i int) any {
 			switch v := v.(*ClearTokenResponse); i {
 			case 0:
 				return &v.state
@@ -872,7 +872,7 @@ func file_token_proto_init() {
 				return nil
 			}
 		}
-		file_token_proto_msgTypes[6].Exporter = func(v interface{}, i int) interface{} {
+		file_token_proto_msgTypes[6].Exporter = func(v any, i int) any {
 			switch v := v.(*ProvideTokenRequest); i {
 			case 0:
 				return &v.state
@@ -884,7 +884,7 @@ func file_token_proto_init() {
 				return nil
 			}
 		}
-		file_token_proto_msgTypes[7].Exporter = func(v interface{}, i int) interface{} {
+		file_token_proto_msgTypes[7].Exporter = func(v any, i int) any {
 			switch v := v.(*ProvideTokenResponse); i {
 			case 0:
 				return &v.state
@@ -896,7 +896,7 @@ func file_token_proto_init() {
 				return nil
 			}
 		}
-		file_token_proto_msgTypes[8].Exporter = func(v interface{}, i int) interface{} {
+		file_token_proto_msgTypes[8].Exporter = func(v any, i int) any {
 			switch v := v.(*ProvideTokenRequest_RegisterProvider); i {
 			case 0:
 				return &v.state
@@ -909,11 +909,11 @@ func file_token_proto_init() {
 			}
 		}
 	}
-	file_token_proto_msgTypes[4].OneofWrappers = []interface{}{
+	file_token_proto_msgTypes[4].OneofWrappers = []any{
 		(*ClearTokenRequest_Value)(nil),
 		(*ClearTokenRequest_All)(nil),
 	}
-	file_token_proto_msgTypes[6].OneofWrappers = []interface{}{
+	file_token_proto_msgTypes[6].OneofWrappers = []any{
 		(*ProvideTokenRequest_Registration)(nil),
 		(*ProvideTokenRequest_Answer)(nil),
 	}

--- a/components/supervisor-api/go/token_grpc.pb.go
+++ b/components/supervisor-api/go/token_grpc.pb.go
@@ -138,7 +138,7 @@ func RegisterTokenServiceServer(s grpc.ServiceRegistrar, srv TokenServiceServer)
 	s.RegisterService(&TokenService_ServiceDesc, srv)
 }
 
-func _TokenService_GetToken_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+func _TokenService_GetToken_Handler(srv any, ctx context.Context, dec func(any) error, interceptor grpc.UnaryServerInterceptor) (any, error) {
 	in := new(GetTokenRequest)
 	if err := dec(in); err != nil {
 		return nil, err
@@ -150,13 +150,13 @@ func _TokenService_GetToken_Handler(srv interface{}, ctx context.Context, dec fu
 		Server:     srv,
 		FullMethod: "/supervisor.TokenService/GetToken",
 	}
-	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+	handler := func(ctx context.Context, req any) (any, error) {
 		return srv.(TokenServiceServer).GetToken(ctx, req.(*GetTokenRequest))
 	}
 	return interceptor(ctx, in, info, handler)
 }
 
-func _TokenService_SetToken_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+func _TokenService_SetToken_Handler(srv any, ctx context.Context, dec func(any) error, interceptor grpc.UnaryServerInterceptor) (any, error) {
 	in := new(SetTokenRequest)
 	if err := dec(in); err != nil {
 		return nil, err
@@ -168,13 +168,13 @@ func _TokenService_SetToken_Handler(srv interface{}, ctx context.Context, dec fu
 		Server:     srv,
 		FullMethod: "/supervisor.TokenService/SetToken",
 	}
-	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+	handler := func(ctx context.Context, req any) (any, error) {
 		return srv.(TokenServiceServer).SetToken(ctx, req.(*SetTokenRequest))
 	}
 	return interceptor(ctx, in, info, handler)
 }
 
-func _TokenService_ClearToken_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+func _TokenService_ClearToken_Handler(srv any, ctx context.Context, dec func(any) error, interceptor grpc.UnaryServerInterceptor) (any, error) {
 	in := new(ClearTokenRequest)
 	if err := dec(in); err != nil {
 		return nil, err
@@ -186,13 +186,13 @@ func _TokenService_ClearToken_Handler(srv interface{}, ctx context.Context, dec 
 		Server:     srv,
 		FullMethod: "/supervisor.TokenService/ClearToken",
 	}
-	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+	handler := func(ctx context.Context, req any) (any, error) {
 		return srv.(TokenServiceServer).ClearToken(ctx, req.(*ClearTokenRequest))
 	}
 	return interceptor(ctx, in, info, handler)
 }
 
-func _TokenService_ProvideToken_Handler(srv interface{}, stream grpc.ServerStream) error {
+func _TokenService_ProvideToken_Handler(srv any, stream grpc.ServerStream) error {
 	return srv.(TokenServiceServer).ProvideToken(&tokenServiceProvideTokenServer{stream})
 }
 

--- a/components/supervisor/pkg/config/gitpod-config-analytics.go
+++ b/components/supervisor/pkg/config/gitpod-config-analytics.go
@@ -117,7 +117,7 @@ func (a *ConfigAnalyzer) computeFields(configs ...*gitpod.GitpodConfig) []string
 	return fields
 }
 
-func (a *ConfigAnalyzer) valueByField(config *gitpod.GitpodConfig, field string) interface{} {
+func (a *ConfigAnalyzer) valueByField(config *gitpod.GitpodConfig, field string) any {
 	defer func() {
 		if err := recover(); err != nil {
 			a.log.WithField("error", err).WithField("field", field).Error("gitpod config analytics: failed to retrieve value from gitpod config")
@@ -129,7 +129,7 @@ func (a *ConfigAnalyzer) valueByField(config *gitpod.GitpodConfig, field string)
 	return reflect.ValueOf(*config).FieldByName(field).Interface()
 }
 
-func (a *ConfigAnalyzer) computeHash(i interface{}) (string, error) {
+func (a *ConfigAnalyzer) computeHash(i any) (string, error) {
 	b, err := json.Marshal(i)
 	if err != nil {
 		return "", err

--- a/components/supervisor/pkg/supervisor/config.go
+++ b/components/supervisor/pkg/supervisor/config.go
@@ -289,14 +289,14 @@ type WorkspaceGitpodToken struct {
 
 // TaskConfig defines gitpod task shape.
 type TaskConfig struct {
-	Name     *string                 `json:"name,omitempty"`
-	Before   *string                 `json:"before,omitempty"`
-	Init     *string                 `json:"init,omitempty"`
-	Prebuild *string                 `json:"prebuild,omitempty"`
-	Command  *string                 `json:"command,omitempty"`
-	Env      *map[string]interface{} `json:"env,omitempty"`
-	OpenIn   *string                 `json:"openIn,omitempty"`
-	OpenMode *string                 `json:"openMode,omitempty"`
+	Name     *string         `json:"name,omitempty"`
+	Before   *string         `json:"before,omitempty"`
+	Init     *string         `json:"init,omitempty"`
+	Prebuild *string         `json:"prebuild,omitempty"`
+	Command  *string         `json:"command,omitempty"`
+	Env      *map[string]any `json:"env,omitempty"`
+	OpenIn   *string         `json:"openIn,omitempty"`
+	OpenMode *string         `json:"openMode,omitempty"`
 }
 
 // Validate validates this configuration.

--- a/components/supervisor/pkg/supervisor/notification.go
+++ b/components/supervisor/pkg/supervisor/notification.go
@@ -216,14 +216,14 @@ func (srv *NotificationService) Respond(ctx context.Context, req *api.RespondReq
 	defer srv.mutex.Unlock()
 	pending, ok := srv.pendingNotifications[req.RequestId]
 	if !ok {
-		log.WithFields(map[string]interface{}{
+		log.WithFields(map[string]any{
 			"RequestId": req.RequestId,
 			"Action":    req.Response.Action,
 		}).Info("Invalid or late response to notification")
 		return nil, status.Errorf(codes.DeadlineExceeded, "Invalid or late response to notification")
 	}
 	if !isActionAllowed(req.Response.Action, pending.message.Request) {
-		log.WithFields(map[string]interface{}{
+		log.WithFields(map[string]any{
 			"Notification": pending.message,
 			"Action":       req.Response.Action,
 		}).Error("Invalid user action on notification")

--- a/components/supervisor/pkg/supervisor/services.go
+++ b/components/supervisor/pkg/supervisor/services.go
@@ -29,7 +29,7 @@ import (
 )
 
 // RegisterableService can register a service.
-type RegisterableService interface{}
+type RegisterableService any
 
 // RegisterableGRPCService can register gRPC services.
 type RegisterableGRPCService interface {

--- a/components/supervisor/pkg/supervisor/supervisor.go
+++ b/components/supervisor/pkg/supervisor/supervisor.go
@@ -1542,7 +1542,7 @@ func analyseConfigChanges(ctx context.Context, wscfg *Config, w analytics.Writer
 					w.Track(analytics.TrackMessage{
 						Identity: analytics.Identity{UserID: info.Workspace.OwnerID},
 						Event:    "gitpod_config_changed",
-						Properties: map[string]interface{}{
+						Properties: map[string]any{
 							"key":         field,
 							"instanceId":  wscfg.WorkspaceInstanceID,
 							"workspaceId": wscfg.WorkspaceID,

--- a/components/supervisor/pkg/supervisor/tasks_test.go
+++ b/components/supervisor/pkg/supervisor/tasks_test.go
@@ -26,8 +26,8 @@ var (
 	failCommand = "exit 1"
 )
 
-var exampleEnvVarInputs = &map[string]interface{}{
-	"JSON_ENV_VAR":     map[string]interface{}{"property": "some string"},
+var exampleEnvVarInputs = &map[string]any{
+	"JSON_ENV_VAR":     map[string]any{"property": "some string"},
 	"JSON_ESCAPED_VAR": "{\"property\":\"some escaped string\"}",
 	"JSON_ARRAY_VAR":   []string{"Hello", "World"},
 	"STRING_ENV_VAR":   "stringEnvironmentVariable",

--- a/components/usage-api/go/v1/billing.pb.go
+++ b/components/usage-api/go/v1/billing.pb.go
@@ -630,7 +630,7 @@ func file_usage_v1_billing_proto_rawDescGZIP() []byte {
 
 var file_usage_v1_billing_proto_enumTypes = make([]protoimpl.EnumInfo, 1)
 var file_usage_v1_billing_proto_msgTypes = make([]protoimpl.MessageInfo, 8)
-var file_usage_v1_billing_proto_goTypes = []interface{}{
+var file_usage_v1_billing_proto_goTypes = []any{
 	(System)(0),                        // 0: usage.v1.System
 	(*UpdateInvoicesRequest)(nil),      // 1: usage.v1.UpdateInvoicesRequest
 	(*UpdateInvoicesResponse)(nil),     // 2: usage.v1.UpdateInvoicesResponse
@@ -671,7 +671,7 @@ func file_usage_v1_billing_proto_init() {
 	}
 	file_usage_v1_usage_proto_init()
 	if !protoimpl.UnsafeEnabled {
-		file_usage_v1_billing_proto_msgTypes[0].Exporter = func(v interface{}, i int) interface{} {
+		file_usage_v1_billing_proto_msgTypes[0].Exporter = func(v any, i int) any {
 			switch v := v.(*UpdateInvoicesRequest); i {
 			case 0:
 				return &v.state
@@ -683,7 +683,7 @@ func file_usage_v1_billing_proto_init() {
 				return nil
 			}
 		}
-		file_usage_v1_billing_proto_msgTypes[1].Exporter = func(v interface{}, i int) interface{} {
+		file_usage_v1_billing_proto_msgTypes[1].Exporter = func(v any, i int) any {
 			switch v := v.(*UpdateInvoicesResponse); i {
 			case 0:
 				return &v.state
@@ -695,7 +695,7 @@ func file_usage_v1_billing_proto_init() {
 				return nil
 			}
 		}
-		file_usage_v1_billing_proto_msgTypes[2].Exporter = func(v interface{}, i int) interface{} {
+		file_usage_v1_billing_proto_msgTypes[2].Exporter = func(v any, i int) any {
 			switch v := v.(*GetUpcomingInvoiceRequest); i {
 			case 0:
 				return &v.state
@@ -707,7 +707,7 @@ func file_usage_v1_billing_proto_init() {
 				return nil
 			}
 		}
-		file_usage_v1_billing_proto_msgTypes[3].Exporter = func(v interface{}, i int) interface{} {
+		file_usage_v1_billing_proto_msgTypes[3].Exporter = func(v any, i int) any {
 			switch v := v.(*GetUpcomingInvoiceResponse); i {
 			case 0:
 				return &v.state
@@ -719,7 +719,7 @@ func file_usage_v1_billing_proto_init() {
 				return nil
 			}
 		}
-		file_usage_v1_billing_proto_msgTypes[4].Exporter = func(v interface{}, i int) interface{} {
+		file_usage_v1_billing_proto_msgTypes[4].Exporter = func(v any, i int) any {
 			switch v := v.(*FinalizeInvoiceRequest); i {
 			case 0:
 				return &v.state
@@ -731,7 +731,7 @@ func file_usage_v1_billing_proto_init() {
 				return nil
 			}
 		}
-		file_usage_v1_billing_proto_msgTypes[5].Exporter = func(v interface{}, i int) interface{} {
+		file_usage_v1_billing_proto_msgTypes[5].Exporter = func(v any, i int) any {
 			switch v := v.(*FinalizeInvoiceResponse); i {
 			case 0:
 				return &v.state
@@ -743,7 +743,7 @@ func file_usage_v1_billing_proto_init() {
 				return nil
 			}
 		}
-		file_usage_v1_billing_proto_msgTypes[6].Exporter = func(v interface{}, i int) interface{} {
+		file_usage_v1_billing_proto_msgTypes[6].Exporter = func(v any, i int) any {
 			switch v := v.(*SetBilledSessionRequest); i {
 			case 0:
 				return &v.state
@@ -755,7 +755,7 @@ func file_usage_v1_billing_proto_init() {
 				return nil
 			}
 		}
-		file_usage_v1_billing_proto_msgTypes[7].Exporter = func(v interface{}, i int) interface{} {
+		file_usage_v1_billing_proto_msgTypes[7].Exporter = func(v any, i int) any {
 			switch v := v.(*SetBilledSessionResponse); i {
 			case 0:
 				return &v.state
@@ -768,7 +768,7 @@ func file_usage_v1_billing_proto_init() {
 			}
 		}
 	}
-	file_usage_v1_billing_proto_msgTypes[2].OneofWrappers = []interface{}{
+	file_usage_v1_billing_proto_msgTypes[2].OneofWrappers = []any{
 		(*GetUpcomingInvoiceRequest_TeamId)(nil),
 		(*GetUpcomingInvoiceRequest_UserId)(nil),
 	}

--- a/components/usage-api/go/v1/billing_grpc.pb.go
+++ b/components/usage-api/go/v1/billing_grpc.pb.go
@@ -130,7 +130,7 @@ func RegisterBillingServiceServer(s grpc.ServiceRegistrar, srv BillingServiceSer
 	s.RegisterService(&BillingService_ServiceDesc, srv)
 }
 
-func _BillingService_UpdateInvoices_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+func _BillingService_UpdateInvoices_Handler(srv any, ctx context.Context, dec func(any) error, interceptor grpc.UnaryServerInterceptor) (any, error) {
 	in := new(UpdateInvoicesRequest)
 	if err := dec(in); err != nil {
 		return nil, err
@@ -142,13 +142,13 @@ func _BillingService_UpdateInvoices_Handler(srv interface{}, ctx context.Context
 		Server:     srv,
 		FullMethod: "/usage.v1.BillingService/UpdateInvoices",
 	}
-	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+	handler := func(ctx context.Context, req any) (any, error) {
 		return srv.(BillingServiceServer).UpdateInvoices(ctx, req.(*UpdateInvoicesRequest))
 	}
 	return interceptor(ctx, in, info, handler)
 }
 
-func _BillingService_GetUpcomingInvoice_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+func _BillingService_GetUpcomingInvoice_Handler(srv any, ctx context.Context, dec func(any) error, interceptor grpc.UnaryServerInterceptor) (any, error) {
 	in := new(GetUpcomingInvoiceRequest)
 	if err := dec(in); err != nil {
 		return nil, err
@@ -160,13 +160,13 @@ func _BillingService_GetUpcomingInvoice_Handler(srv interface{}, ctx context.Con
 		Server:     srv,
 		FullMethod: "/usage.v1.BillingService/GetUpcomingInvoice",
 	}
-	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+	handler := func(ctx context.Context, req any) (any, error) {
 		return srv.(BillingServiceServer).GetUpcomingInvoice(ctx, req.(*GetUpcomingInvoiceRequest))
 	}
 	return interceptor(ctx, in, info, handler)
 }
 
-func _BillingService_FinalizeInvoice_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+func _BillingService_FinalizeInvoice_Handler(srv any, ctx context.Context, dec func(any) error, interceptor grpc.UnaryServerInterceptor) (any, error) {
 	in := new(FinalizeInvoiceRequest)
 	if err := dec(in); err != nil {
 		return nil, err
@@ -178,13 +178,13 @@ func _BillingService_FinalizeInvoice_Handler(srv interface{}, ctx context.Contex
 		Server:     srv,
 		FullMethod: "/usage.v1.BillingService/FinalizeInvoice",
 	}
-	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+	handler := func(ctx context.Context, req any) (any, error) {
 		return srv.(BillingServiceServer).FinalizeInvoice(ctx, req.(*FinalizeInvoiceRequest))
 	}
 	return interceptor(ctx, in, info, handler)
 }
 
-func _BillingService_SetBilledSession_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+func _BillingService_SetBilledSession_Handler(srv any, ctx context.Context, dec func(any) error, interceptor grpc.UnaryServerInterceptor) (any, error) {
 	in := new(SetBilledSessionRequest)
 	if err := dec(in); err != nil {
 		return nil, err
@@ -196,7 +196,7 @@ func _BillingService_SetBilledSession_Handler(srv interface{}, ctx context.Conte
 		Server:     srv,
 		FullMethod: "/usage.v1.BillingService/SetBilledSession",
 	}
-	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+	handler := func(ctx context.Context, req any) (any, error) {
 		return srv.(BillingServiceServer).SetBilledSession(ctx, req.(*SetBilledSessionRequest))
 	}
 	return interceptor(ctx, in, info, handler)

--- a/components/usage-api/go/v1/pagination.pb.go
+++ b/components/usage-api/go/v1/pagination.pb.go
@@ -110,7 +110,7 @@ func file_usage_v1_pagination_proto_rawDescGZIP() []byte {
 }
 
 var file_usage_v1_pagination_proto_msgTypes = make([]protoimpl.MessageInfo, 1)
-var file_usage_v1_pagination_proto_goTypes = []interface{}{
+var file_usage_v1_pagination_proto_goTypes = []any{
 	(*Pagination)(nil), // 0: usage.v1.Pagination
 }
 var file_usage_v1_pagination_proto_depIdxs = []int32{
@@ -127,7 +127,7 @@ func file_usage_v1_pagination_proto_init() {
 		return
 	}
 	if !protoimpl.UnsafeEnabled {
-		file_usage_v1_pagination_proto_msgTypes[0].Exporter = func(v interface{}, i int) interface{} {
+		file_usage_v1_pagination_proto_msgTypes[0].Exporter = func(v any, i int) any {
 			switch v := v.(*Pagination); i {
 			case 0:
 				return &v.state

--- a/components/usage-api/go/v1/usage.pb.go
+++ b/components/usage-api/go/v1/usage.pb.go
@@ -892,7 +892,7 @@ func file_usage_v1_usage_proto_rawDescGZIP() []byte {
 
 var file_usage_v1_usage_proto_enumTypes = make([]protoimpl.EnumInfo, 1)
 var file_usage_v1_usage_proto_msgTypes = make([]protoimpl.MessageInfo, 10)
-var file_usage_v1_usage_proto_goTypes = []interface{}{
+var file_usage_v1_usage_proto_goTypes = []any{
 	(ListBilledUsageRequest_Ordering)(0), // 0: usage.v1.ListBilledUsageRequest.Ordering
 	(*ListBilledUsageRequest)(nil),       // 1: usage.v1.ListBilledUsageRequest
 	(*PaginatedRequest)(nil),             // 2: usage.v1.PaginatedRequest
@@ -938,7 +938,7 @@ func file_usage_v1_usage_proto_init() {
 		return
 	}
 	if !protoimpl.UnsafeEnabled {
-		file_usage_v1_usage_proto_msgTypes[0].Exporter = func(v interface{}, i int) interface{} {
+		file_usage_v1_usage_proto_msgTypes[0].Exporter = func(v any, i int) any {
 			switch v := v.(*ListBilledUsageRequest); i {
 			case 0:
 				return &v.state
@@ -950,7 +950,7 @@ func file_usage_v1_usage_proto_init() {
 				return nil
 			}
 		}
-		file_usage_v1_usage_proto_msgTypes[1].Exporter = func(v interface{}, i int) interface{} {
+		file_usage_v1_usage_proto_msgTypes[1].Exporter = func(v any, i int) any {
 			switch v := v.(*PaginatedRequest); i {
 			case 0:
 				return &v.state
@@ -962,7 +962,7 @@ func file_usage_v1_usage_proto_init() {
 				return nil
 			}
 		}
-		file_usage_v1_usage_proto_msgTypes[2].Exporter = func(v interface{}, i int) interface{} {
+		file_usage_v1_usage_proto_msgTypes[2].Exporter = func(v any, i int) any {
 			switch v := v.(*ListBilledUsageResponse); i {
 			case 0:
 				return &v.state
@@ -974,7 +974,7 @@ func file_usage_v1_usage_proto_init() {
 				return nil
 			}
 		}
-		file_usage_v1_usage_proto_msgTypes[3].Exporter = func(v interface{}, i int) interface{} {
+		file_usage_v1_usage_proto_msgTypes[3].Exporter = func(v any, i int) any {
 			switch v := v.(*PaginatedResponse); i {
 			case 0:
 				return &v.state
@@ -986,7 +986,7 @@ func file_usage_v1_usage_proto_init() {
 				return nil
 			}
 		}
-		file_usage_v1_usage_proto_msgTypes[4].Exporter = func(v interface{}, i int) interface{} {
+		file_usage_v1_usage_proto_msgTypes[4].Exporter = func(v any, i int) any {
 			switch v := v.(*BilledSession); i {
 			case 0:
 				return &v.state
@@ -998,7 +998,7 @@ func file_usage_v1_usage_proto_init() {
 				return nil
 			}
 		}
-		file_usage_v1_usage_proto_msgTypes[5].Exporter = func(v interface{}, i int) interface{} {
+		file_usage_v1_usage_proto_msgTypes[5].Exporter = func(v any, i int) any {
 			switch v := v.(*ReconcileUsageRequest); i {
 			case 0:
 				return &v.state
@@ -1010,7 +1010,7 @@ func file_usage_v1_usage_proto_init() {
 				return nil
 			}
 		}
-		file_usage_v1_usage_proto_msgTypes[6].Exporter = func(v interface{}, i int) interface{} {
+		file_usage_v1_usage_proto_msgTypes[6].Exporter = func(v any, i int) any {
 			switch v := v.(*ReconcileUsageResponse); i {
 			case 0:
 				return &v.state
@@ -1022,7 +1022,7 @@ func file_usage_v1_usage_proto_init() {
 				return nil
 			}
 		}
-		file_usage_v1_usage_proto_msgTypes[7].Exporter = func(v interface{}, i int) interface{} {
+		file_usage_v1_usage_proto_msgTypes[7].Exporter = func(v any, i int) any {
 			switch v := v.(*GetCostCenterRequest); i {
 			case 0:
 				return &v.state
@@ -1034,7 +1034,7 @@ func file_usage_v1_usage_proto_init() {
 				return nil
 			}
 		}
-		file_usage_v1_usage_proto_msgTypes[8].Exporter = func(v interface{}, i int) interface{} {
+		file_usage_v1_usage_proto_msgTypes[8].Exporter = func(v any, i int) any {
 			switch v := v.(*GetCostCenterResponse); i {
 			case 0:
 				return &v.state
@@ -1046,7 +1046,7 @@ func file_usage_v1_usage_proto_init() {
 				return nil
 			}
 		}
-		file_usage_v1_usage_proto_msgTypes[9].Exporter = func(v interface{}, i int) interface{} {
+		file_usage_v1_usage_proto_msgTypes[9].Exporter = func(v any, i int) any {
 			switch v := v.(*CostCenter); i {
 			case 0:
 				return &v.state

--- a/components/usage-api/go/v1/usage_grpc.pb.go
+++ b/components/usage-api/go/v1/usage_grpc.pb.go
@@ -108,7 +108,7 @@ func RegisterUsageServiceServer(s grpc.ServiceRegistrar, srv UsageServiceServer)
 	s.RegisterService(&UsageService_ServiceDesc, srv)
 }
 
-func _UsageService_ListBilledUsage_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+func _UsageService_ListBilledUsage_Handler(srv any, ctx context.Context, dec func(any) error, interceptor grpc.UnaryServerInterceptor) (any, error) {
 	in := new(ListBilledUsageRequest)
 	if err := dec(in); err != nil {
 		return nil, err
@@ -120,13 +120,13 @@ func _UsageService_ListBilledUsage_Handler(srv interface{}, ctx context.Context,
 		Server:     srv,
 		FullMethod: "/usage.v1.UsageService/ListBilledUsage",
 	}
-	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+	handler := func(ctx context.Context, req any) (any, error) {
 		return srv.(UsageServiceServer).ListBilledUsage(ctx, req.(*ListBilledUsageRequest))
 	}
 	return interceptor(ctx, in, info, handler)
 }
 
-func _UsageService_ReconcileUsage_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+func _UsageService_ReconcileUsage_Handler(srv any, ctx context.Context, dec func(any) error, interceptor grpc.UnaryServerInterceptor) (any, error) {
 	in := new(ReconcileUsageRequest)
 	if err := dec(in); err != nil {
 		return nil, err
@@ -138,13 +138,13 @@ func _UsageService_ReconcileUsage_Handler(srv interface{}, ctx context.Context, 
 		Server:     srv,
 		FullMethod: "/usage.v1.UsageService/ReconcileUsage",
 	}
-	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+	handler := func(ctx context.Context, req any) (any, error) {
 		return srv.(UsageServiceServer).ReconcileUsage(ctx, req.(*ReconcileUsageRequest))
 	}
 	return interceptor(ctx, in, info, handler)
 }
 
-func _UsageService_GetCostCenter_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+func _UsageService_GetCostCenter_Handler(srv any, ctx context.Context, dec func(any) error, interceptor grpc.UnaryServerInterceptor) (any, error) {
 	in := new(GetCostCenterRequest)
 	if err := dec(in); err != nil {
 		return nil, err
@@ -156,7 +156,7 @@ func _UsageService_GetCostCenter_Handler(srv interface{}, ctx context.Context, d
 		Server:     srv,
 		FullMethod: "/usage.v1.UsageService/GetCostCenter",
 	}
-	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+	handler := func(ctx context.Context, req any) (any, error) {
 		return srv.(UsageServiceServer).GetCostCenter(ctx, req.(*GetCostCenterRequest))
 	}
 	return interceptor(ctx, in, info, handler)

--- a/components/usage/pkg/db/project_test.go
+++ b/components/usage/pkg/db/project_test.go
@@ -15,7 +15,7 @@ import (
 	"testing"
 )
 
-var projectJSON = map[string]interface{}{
+var projectJSON = map[string]any{
 	"id":                uuid.New().String(),
 	"cloneUrl":          "https://github.com/gptest1/gptest1-repo1-private.git",
 	"teamId":            "0e433063-1358-4892-9ed2-68e273d17d07",
@@ -46,14 +46,14 @@ func TestProject_ReadExistingRecords(t *testing.T) {
 	require.NoError(t, conn.Where("id = ?", project.ID).Delete(&db.Project{}).Error)
 }
 
-func insertRawProject(t *testing.T, conn *gorm.DB, obj map[string]interface{}) uuid.UUID {
+func insertRawProject(t *testing.T, conn *gorm.DB, obj map[string]any) uuid.UUID {
 	columns := []string{
 		"id", "cloneUrl", "teamId", "appInstallationId", "creationTime", "deleted", "_lastModified", "name", "config", "markedDeleted", "userId", "slug", "settings",
 	}
 	statement := fmt.Sprintf(`INSERT INTO d_b_project (%s) VALUES ?;`, strings.Join(columns, ", "))
 	id := uuid.MustParse(obj["id"].(string))
 
-	var values []interface{}
+	var values []any
 	for _, col := range columns {
 		val, ok := obj[col]
 		if !ok {

--- a/components/usage/pkg/db/types.go
+++ b/components/usage/pkg/db/types.go
@@ -31,7 +31,7 @@ type VarcharTime struct {
 }
 
 // Scan implements the Scanner interface.
-func (n *VarcharTime) Scan(value interface{}) error {
+func (n *VarcharTime) Scan(value any) error {
 	if value == nil {
 		n.valid = false
 		return nil

--- a/components/usage/pkg/db/types_test.go
+++ b/components/usage/pkg/db/types_test.go
@@ -20,7 +20,7 @@ func TestVarcharTime_Scan(t *testing.T) {
 	for _, scenario := range []struct {
 		Name string
 
-		Input    interface{}
+		Input    any
 		Expected Expectation
 	}{
 		{

--- a/components/workspacekit/cmd/rings.go
+++ b/components/workspacekit/cmd/rings.go
@@ -337,7 +337,7 @@ var ring1Cmd = &cobra.Command{
 				m.FSType = "none"
 			}
 
-			log.WithFields(map[string]interface{}{
+			log.WithFields(map[string]any{
 				"source": m.Source,
 				"target": dst,
 				"fstype": m.FSType,

--- a/components/workspacekit/pkg/seccomp/notify.go
+++ b/components/workspacekit/pkg/seccomp/notify.go
@@ -210,7 +210,7 @@ type BindEvent struct {
 
 // Mount handles mount syscalls
 func (h *InWorkspaceHandler) Mount(req *libseccomp.ScmpNotifReq) (val uint64, errno int32, flags uint32) {
-	log := log.WithFields(map[string]interface{}{
+	log := log.WithFields(map[string]any{
 		"syscall":          "mount",
 		log.WorkspaceField: h.WorkspaceId,
 		"pid":              req.Pid,
@@ -246,7 +246,7 @@ func (h *InWorkspaceHandler) Mount(req *libseccomp.ScmpNotifReq) (val uint64, er
 		return Errno(unix.EFAULT)
 	}
 
-	log.WithFields(map[string]interface{}{
+	log.WithFields(map[string]any{
 		"source": source,
 		"dest":   dest,
 		"fstype": filesystem,
@@ -316,7 +316,7 @@ func (h *InWorkspaceHandler) Mount(req *libseccomp.ScmpNotifReq) (val uint64, er
 // Umount handles umount and umount2 syscalls
 func (h *InWorkspaceHandler) Umount(req *libseccomp.ScmpNotifReq) (val uint64, errno int32, flags uint32) {
 	nme, _ := req.Data.Syscall.GetName()
-	log := log.WithFields(map[string]interface{}{
+	log := log.WithFields(map[string]any{
 		"syscall":          nme,
 		log.WorkspaceField: h.WorkspaceId,
 		"pid":              req.Pid,
@@ -396,7 +396,7 @@ func (h *InWorkspaceHandler) Umount(req *libseccomp.ScmpNotifReq) (val uint64, e
 }
 
 func (h *InWorkspaceHandler) Bind(req *libseccomp.ScmpNotifReq) (val uint64, errno int32, flags uint32) {
-	log := log.WithFields(map[string]interface{}{
+	log := log.WithFields(map[string]any{
 		"syscall":          "bind",
 		log.WorkspaceField: h.WorkspaceId,
 		"pid":              req.Pid,
@@ -442,7 +442,7 @@ func (h *InWorkspaceHandler) Bind(req *libseccomp.ScmpNotifReq) (val uint64, err
 }
 
 func (h *InWorkspaceHandler) Chown(req *libseccomp.ScmpNotifReq) (val uint64, errno int32, flags uint32) {
-	log := log.WithFields(map[string]interface{}{
+	log := log.WithFields(map[string]any{
 		"syscall":          "chown",
 		log.WorkspaceField: h.WorkspaceId,
 		"pid":              req.Pid,

--- a/components/ws-daemon-api/go/daemon.pb.go
+++ b/components/ws-daemon-api/go/daemon.pb.go
@@ -826,7 +826,7 @@ func file_daemon_proto_rawDescGZIP() []byte {
 
 var file_daemon_proto_enumTypes = make([]protoimpl.EnumInfo, 1)
 var file_daemon_proto_msgTypes = make([]protoimpl.MessageInfo, 11)
-var file_daemon_proto_goTypes = []interface{}{
+var file_daemon_proto_goTypes = []any{
 	(WorkspaceContentState)(0),       // 0: wsdaemon.WorkspaceContentState
 	(*InitWorkspaceRequest)(nil),     // 1: wsdaemon.InitWorkspaceRequest
 	(*WorkspaceMetadata)(nil),        // 2: wsdaemon.WorkspaceMetadata
@@ -869,7 +869,7 @@ func file_daemon_proto_init() {
 		return
 	}
 	if !protoimpl.UnsafeEnabled {
-		file_daemon_proto_msgTypes[0].Exporter = func(v interface{}, i int) interface{} {
+		file_daemon_proto_msgTypes[0].Exporter = func(v any, i int) any {
 			switch v := v.(*InitWorkspaceRequest); i {
 			case 0:
 				return &v.state
@@ -881,7 +881,7 @@ func file_daemon_proto_init() {
 				return nil
 			}
 		}
-		file_daemon_proto_msgTypes[1].Exporter = func(v interface{}, i int) interface{} {
+		file_daemon_proto_msgTypes[1].Exporter = func(v any, i int) any {
 			switch v := v.(*WorkspaceMetadata); i {
 			case 0:
 				return &v.state
@@ -893,7 +893,7 @@ func file_daemon_proto_init() {
 				return nil
 			}
 		}
-		file_daemon_proto_msgTypes[2].Exporter = func(v interface{}, i int) interface{} {
+		file_daemon_proto_msgTypes[2].Exporter = func(v any, i int) any {
 			switch v := v.(*InitWorkspaceResponse); i {
 			case 0:
 				return &v.state
@@ -905,7 +905,7 @@ func file_daemon_proto_init() {
 				return nil
 			}
 		}
-		file_daemon_proto_msgTypes[3].Exporter = func(v interface{}, i int) interface{} {
+		file_daemon_proto_msgTypes[3].Exporter = func(v any, i int) any {
 			switch v := v.(*WaitForInitRequest); i {
 			case 0:
 				return &v.state
@@ -917,7 +917,7 @@ func file_daemon_proto_init() {
 				return nil
 			}
 		}
-		file_daemon_proto_msgTypes[4].Exporter = func(v interface{}, i int) interface{} {
+		file_daemon_proto_msgTypes[4].Exporter = func(v any, i int) any {
 			switch v := v.(*WaitForInitResponse); i {
 			case 0:
 				return &v.state
@@ -929,7 +929,7 @@ func file_daemon_proto_init() {
 				return nil
 			}
 		}
-		file_daemon_proto_msgTypes[5].Exporter = func(v interface{}, i int) interface{} {
+		file_daemon_proto_msgTypes[5].Exporter = func(v any, i int) any {
 			switch v := v.(*TakeSnapshotRequest); i {
 			case 0:
 				return &v.state
@@ -941,7 +941,7 @@ func file_daemon_proto_init() {
 				return nil
 			}
 		}
-		file_daemon_proto_msgTypes[6].Exporter = func(v interface{}, i int) interface{} {
+		file_daemon_proto_msgTypes[6].Exporter = func(v any, i int) any {
 			switch v := v.(*TakeSnapshotResponse); i {
 			case 0:
 				return &v.state
@@ -953,7 +953,7 @@ func file_daemon_proto_init() {
 				return nil
 			}
 		}
-		file_daemon_proto_msgTypes[7].Exporter = func(v interface{}, i int) interface{} {
+		file_daemon_proto_msgTypes[7].Exporter = func(v any, i int) any {
 			switch v := v.(*DisposeWorkspaceRequest); i {
 			case 0:
 				return &v.state
@@ -965,7 +965,7 @@ func file_daemon_proto_init() {
 				return nil
 			}
 		}
-		file_daemon_proto_msgTypes[8].Exporter = func(v interface{}, i int) interface{} {
+		file_daemon_proto_msgTypes[8].Exporter = func(v any, i int) any {
 			switch v := v.(*DisposeWorkspaceResponse); i {
 			case 0:
 				return &v.state
@@ -977,7 +977,7 @@ func file_daemon_proto_init() {
 				return nil
 			}
 		}
-		file_daemon_proto_msgTypes[9].Exporter = func(v interface{}, i int) interface{} {
+		file_daemon_proto_msgTypes[9].Exporter = func(v any, i int) any {
 			switch v := v.(*BackupWorkspaceRequest); i {
 			case 0:
 				return &v.state
@@ -989,7 +989,7 @@ func file_daemon_proto_init() {
 				return nil
 			}
 		}
-		file_daemon_proto_msgTypes[10].Exporter = func(v interface{}, i int) interface{} {
+		file_daemon_proto_msgTypes[10].Exporter = func(v any, i int) any {
 			switch v := v.(*BackupWorkspaceResponse); i {
 			case 0:
 				return &v.state

--- a/components/ws-daemon-api/go/daemon_grpc.pb.go
+++ b/components/ws-daemon-api/go/daemon_grpc.pb.go
@@ -145,7 +145,7 @@ func RegisterWorkspaceContentServiceServer(s grpc.ServiceRegistrar, srv Workspac
 	s.RegisterService(&WorkspaceContentService_ServiceDesc, srv)
 }
 
-func _WorkspaceContentService_InitWorkspace_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+func _WorkspaceContentService_InitWorkspace_Handler(srv any, ctx context.Context, dec func(any) error, interceptor grpc.UnaryServerInterceptor) (any, error) {
 	in := new(InitWorkspaceRequest)
 	if err := dec(in); err != nil {
 		return nil, err
@@ -157,13 +157,13 @@ func _WorkspaceContentService_InitWorkspace_Handler(srv interface{}, ctx context
 		Server:     srv,
 		FullMethod: "/wsdaemon.WorkspaceContentService/InitWorkspace",
 	}
-	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+	handler := func(ctx context.Context, req any) (any, error) {
 		return srv.(WorkspaceContentServiceServer).InitWorkspace(ctx, req.(*InitWorkspaceRequest))
 	}
 	return interceptor(ctx, in, info, handler)
 }
 
-func _WorkspaceContentService_WaitForInit_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+func _WorkspaceContentService_WaitForInit_Handler(srv any, ctx context.Context, dec func(any) error, interceptor grpc.UnaryServerInterceptor) (any, error) {
 	in := new(WaitForInitRequest)
 	if err := dec(in); err != nil {
 		return nil, err
@@ -175,13 +175,13 @@ func _WorkspaceContentService_WaitForInit_Handler(srv interface{}, ctx context.C
 		Server:     srv,
 		FullMethod: "/wsdaemon.WorkspaceContentService/WaitForInit",
 	}
-	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+	handler := func(ctx context.Context, req any) (any, error) {
 		return srv.(WorkspaceContentServiceServer).WaitForInit(ctx, req.(*WaitForInitRequest))
 	}
 	return interceptor(ctx, in, info, handler)
 }
 
-func _WorkspaceContentService_TakeSnapshot_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+func _WorkspaceContentService_TakeSnapshot_Handler(srv any, ctx context.Context, dec func(any) error, interceptor grpc.UnaryServerInterceptor) (any, error) {
 	in := new(TakeSnapshotRequest)
 	if err := dec(in); err != nil {
 		return nil, err
@@ -193,13 +193,13 @@ func _WorkspaceContentService_TakeSnapshot_Handler(srv interface{}, ctx context.
 		Server:     srv,
 		FullMethod: "/wsdaemon.WorkspaceContentService/TakeSnapshot",
 	}
-	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+	handler := func(ctx context.Context, req any) (any, error) {
 		return srv.(WorkspaceContentServiceServer).TakeSnapshot(ctx, req.(*TakeSnapshotRequest))
 	}
 	return interceptor(ctx, in, info, handler)
 }
 
-func _WorkspaceContentService_DisposeWorkspace_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+func _WorkspaceContentService_DisposeWorkspace_Handler(srv any, ctx context.Context, dec func(any) error, interceptor grpc.UnaryServerInterceptor) (any, error) {
 	in := new(DisposeWorkspaceRequest)
 	if err := dec(in); err != nil {
 		return nil, err
@@ -211,13 +211,13 @@ func _WorkspaceContentService_DisposeWorkspace_Handler(srv interface{}, ctx cont
 		Server:     srv,
 		FullMethod: "/wsdaemon.WorkspaceContentService/DisposeWorkspace",
 	}
-	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+	handler := func(ctx context.Context, req any) (any, error) {
 		return srv.(WorkspaceContentServiceServer).DisposeWorkspace(ctx, req.(*DisposeWorkspaceRequest))
 	}
 	return interceptor(ctx, in, info, handler)
 }
 
-func _WorkspaceContentService_BackupWorkspace_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+func _WorkspaceContentService_BackupWorkspace_Handler(srv any, ctx context.Context, dec func(any) error, interceptor grpc.UnaryServerInterceptor) (any, error) {
 	in := new(BackupWorkspaceRequest)
 	if err := dec(in); err != nil {
 		return nil, err
@@ -229,7 +229,7 @@ func _WorkspaceContentService_BackupWorkspace_Handler(srv interface{}, ctx conte
 		Server:     srv,
 		FullMethod: "/wsdaemon.WorkspaceContentService/BackupWorkspace",
 	}
-	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+	handler := func(ctx context.Context, req any) (any, error) {
 		return srv.(WorkspaceContentServiceServer).BackupWorkspace(ctx, req.(*BackupWorkspaceRequest))
 	}
 	return interceptor(ctx, in, info, handler)

--- a/components/ws-daemon-api/go/mock/mock.go
+++ b/components/ws-daemon-api/go/mock/mock.go
@@ -43,7 +43,7 @@ func (m *MockWorkspaceContentServiceClient) EXPECT() *MockWorkspaceContentServic
 // BackupWorkspace mocks base method.
 func (m *MockWorkspaceContentServiceClient) BackupWorkspace(arg0 context.Context, arg1 *api.BackupWorkspaceRequest, arg2 ...grpc.CallOption) (*api.BackupWorkspaceResponse, error) {
 	m.ctrl.T.Helper()
-	varargs := []interface{}{arg0, arg1}
+	varargs := []any{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
 	}
@@ -54,16 +54,16 @@ func (m *MockWorkspaceContentServiceClient) BackupWorkspace(arg0 context.Context
 }
 
 // BackupWorkspace indicates an expected call of BackupWorkspace.
-func (mr *MockWorkspaceContentServiceClientMockRecorder) BackupWorkspace(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+func (mr *MockWorkspaceContentServiceClientMockRecorder) BackupWorkspace(arg0, arg1 any, arg2 ...any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	varargs := append([]interface{}{arg0, arg1}, arg2...)
+	varargs := append([]any{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BackupWorkspace", reflect.TypeOf((*MockWorkspaceContentServiceClient)(nil).BackupWorkspace), varargs...)
 }
 
 // DisposeWorkspace mocks base method.
 func (m *MockWorkspaceContentServiceClient) DisposeWorkspace(arg0 context.Context, arg1 *api.DisposeWorkspaceRequest, arg2 ...grpc.CallOption) (*api.DisposeWorkspaceResponse, error) {
 	m.ctrl.T.Helper()
-	varargs := []interface{}{arg0, arg1}
+	varargs := []any{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
 	}
@@ -74,16 +74,16 @@ func (m *MockWorkspaceContentServiceClient) DisposeWorkspace(arg0 context.Contex
 }
 
 // DisposeWorkspace indicates an expected call of DisposeWorkspace.
-func (mr *MockWorkspaceContentServiceClientMockRecorder) DisposeWorkspace(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+func (mr *MockWorkspaceContentServiceClientMockRecorder) DisposeWorkspace(arg0, arg1 any, arg2 ...any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	varargs := append([]interface{}{arg0, arg1}, arg2...)
+	varargs := append([]any{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DisposeWorkspace", reflect.TypeOf((*MockWorkspaceContentServiceClient)(nil).DisposeWorkspace), varargs...)
 }
 
 // InitWorkspace mocks base method.
 func (m *MockWorkspaceContentServiceClient) InitWorkspace(arg0 context.Context, arg1 *api.InitWorkspaceRequest, arg2 ...grpc.CallOption) (*api.InitWorkspaceResponse, error) {
 	m.ctrl.T.Helper()
-	varargs := []interface{}{arg0, arg1}
+	varargs := []any{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
 	}
@@ -94,16 +94,16 @@ func (m *MockWorkspaceContentServiceClient) InitWorkspace(arg0 context.Context, 
 }
 
 // InitWorkspace indicates an expected call of InitWorkspace.
-func (mr *MockWorkspaceContentServiceClientMockRecorder) InitWorkspace(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+func (mr *MockWorkspaceContentServiceClientMockRecorder) InitWorkspace(arg0, arg1 any, arg2 ...any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	varargs := append([]interface{}{arg0, arg1}, arg2...)
+	varargs := append([]any{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InitWorkspace", reflect.TypeOf((*MockWorkspaceContentServiceClient)(nil).InitWorkspace), varargs...)
 }
 
 // TakeSnapshot mocks base method.
 func (m *MockWorkspaceContentServiceClient) TakeSnapshot(arg0 context.Context, arg1 *api.TakeSnapshotRequest, arg2 ...grpc.CallOption) (*api.TakeSnapshotResponse, error) {
 	m.ctrl.T.Helper()
-	varargs := []interface{}{arg0, arg1}
+	varargs := []any{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
 	}
@@ -114,16 +114,16 @@ func (m *MockWorkspaceContentServiceClient) TakeSnapshot(arg0 context.Context, a
 }
 
 // TakeSnapshot indicates an expected call of TakeSnapshot.
-func (mr *MockWorkspaceContentServiceClientMockRecorder) TakeSnapshot(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+func (mr *MockWorkspaceContentServiceClientMockRecorder) TakeSnapshot(arg0, arg1 any, arg2 ...any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	varargs := append([]interface{}{arg0, arg1}, arg2...)
+	varargs := append([]any{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TakeSnapshot", reflect.TypeOf((*MockWorkspaceContentServiceClient)(nil).TakeSnapshot), varargs...)
 }
 
 // WaitForInit mocks base method.
 func (m *MockWorkspaceContentServiceClient) WaitForInit(arg0 context.Context, arg1 *api.WaitForInitRequest, arg2 ...grpc.CallOption) (*api.WaitForInitResponse, error) {
 	m.ctrl.T.Helper()
-	varargs := []interface{}{arg0, arg1}
+	varargs := []any{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
 	}
@@ -134,9 +134,9 @@ func (m *MockWorkspaceContentServiceClient) WaitForInit(arg0 context.Context, ar
 }
 
 // WaitForInit indicates an expected call of WaitForInit.
-func (mr *MockWorkspaceContentServiceClientMockRecorder) WaitForInit(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+func (mr *MockWorkspaceContentServiceClientMockRecorder) WaitForInit(arg0, arg1 any, arg2 ...any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	varargs := append([]interface{}{arg0, arg1}, arg2...)
+	varargs := append([]any{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WaitForInit", reflect.TypeOf((*MockWorkspaceContentServiceClient)(nil).WaitForInit), varargs...)
 }
 
@@ -174,7 +174,7 @@ func (m *MockWorkspaceContentServiceServer) BackupWorkspace(arg0 context.Context
 }
 
 // BackupWorkspace indicates an expected call of BackupWorkspace.
-func (mr *MockWorkspaceContentServiceServerMockRecorder) BackupWorkspace(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockWorkspaceContentServiceServerMockRecorder) BackupWorkspace(arg0, arg1 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BackupWorkspace", reflect.TypeOf((*MockWorkspaceContentServiceServer)(nil).BackupWorkspace), arg0, arg1)
 }
@@ -189,7 +189,7 @@ func (m *MockWorkspaceContentServiceServer) DisposeWorkspace(arg0 context.Contex
 }
 
 // DisposeWorkspace indicates an expected call of DisposeWorkspace.
-func (mr *MockWorkspaceContentServiceServerMockRecorder) DisposeWorkspace(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockWorkspaceContentServiceServerMockRecorder) DisposeWorkspace(arg0, arg1 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DisposeWorkspace", reflect.TypeOf((*MockWorkspaceContentServiceServer)(nil).DisposeWorkspace), arg0, arg1)
 }
@@ -204,7 +204,7 @@ func (m *MockWorkspaceContentServiceServer) InitWorkspace(arg0 context.Context, 
 }
 
 // InitWorkspace indicates an expected call of InitWorkspace.
-func (mr *MockWorkspaceContentServiceServerMockRecorder) InitWorkspace(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockWorkspaceContentServiceServerMockRecorder) InitWorkspace(arg0, arg1 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InitWorkspace", reflect.TypeOf((*MockWorkspaceContentServiceServer)(nil).InitWorkspace), arg0, arg1)
 }
@@ -219,7 +219,7 @@ func (m *MockWorkspaceContentServiceServer) TakeSnapshot(arg0 context.Context, a
 }
 
 // TakeSnapshot indicates an expected call of TakeSnapshot.
-func (mr *MockWorkspaceContentServiceServerMockRecorder) TakeSnapshot(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockWorkspaceContentServiceServerMockRecorder) TakeSnapshot(arg0, arg1 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TakeSnapshot", reflect.TypeOf((*MockWorkspaceContentServiceServer)(nil).TakeSnapshot), arg0, arg1)
 }
@@ -234,7 +234,7 @@ func (m *MockWorkspaceContentServiceServer) WaitForInit(arg0 context.Context, ar
 }
 
 // WaitForInit indicates an expected call of WaitForInit.
-func (mr *MockWorkspaceContentServiceServerMockRecorder) WaitForInit(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockWorkspaceContentServiceServerMockRecorder) WaitForInit(arg0, arg1 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WaitForInit", reflect.TypeOf((*MockWorkspaceContentServiceServer)(nil).WaitForInit), arg0, arg1)
 }
@@ -277,7 +277,7 @@ func (m *MockInWorkspaceServiceClient) EXPECT() *MockInWorkspaceServiceClientMoc
 // EvacuateCGroup mocks base method.
 func (m *MockInWorkspaceServiceClient) EvacuateCGroup(arg0 context.Context, arg1 *api.EvacuateCGroupRequest, arg2 ...grpc.CallOption) (*api.EvacuateCGroupResponse, error) {
 	m.ctrl.T.Helper()
-	varargs := []interface{}{arg0, arg1}
+	varargs := []any{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
 	}
@@ -288,16 +288,16 @@ func (m *MockInWorkspaceServiceClient) EvacuateCGroup(arg0 context.Context, arg1
 }
 
 // EvacuateCGroup indicates an expected call of EvacuateCGroup.
-func (mr *MockInWorkspaceServiceClientMockRecorder) EvacuateCGroup(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+func (mr *MockInWorkspaceServiceClientMockRecorder) EvacuateCGroup(arg0, arg1 any, arg2 ...any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	varargs := append([]interface{}{arg0, arg1}, arg2...)
+	varargs := append([]any{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EvacuateCGroup", reflect.TypeOf((*MockInWorkspaceServiceClient)(nil).EvacuateCGroup), varargs...)
 }
 
 // MountProc mocks base method.
 func (m *MockInWorkspaceServiceClient) MountProc(arg0 context.Context, arg1 *api.MountProcRequest, arg2 ...grpc.CallOption) (*api.MountProcResponse, error) {
 	m.ctrl.T.Helper()
-	varargs := []interface{}{arg0, arg1}
+	varargs := []any{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
 	}
@@ -308,16 +308,16 @@ func (m *MockInWorkspaceServiceClient) MountProc(arg0 context.Context, arg1 *api
 }
 
 // MountProc indicates an expected call of MountProc.
-func (mr *MockInWorkspaceServiceClientMockRecorder) MountProc(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+func (mr *MockInWorkspaceServiceClientMockRecorder) MountProc(arg0, arg1 any, arg2 ...any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	varargs := append([]interface{}{arg0, arg1}, arg2...)
+	varargs := append([]any{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MountProc", reflect.TypeOf((*MockInWorkspaceServiceClient)(nil).MountProc), varargs...)
 }
 
 // MountSysfs mocks base method.
 func (m *MockInWorkspaceServiceClient) MountSysfs(arg0 context.Context, arg1 *api.MountProcRequest, arg2 ...grpc.CallOption) (*api.MountProcResponse, error) {
 	m.ctrl.T.Helper()
-	varargs := []interface{}{arg0, arg1}
+	varargs := []any{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
 	}
@@ -328,16 +328,16 @@ func (m *MockInWorkspaceServiceClient) MountSysfs(arg0 context.Context, arg1 *ap
 }
 
 // MountSysfs indicates an expected call of MountSysfs.
-func (mr *MockInWorkspaceServiceClientMockRecorder) MountSysfs(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+func (mr *MockInWorkspaceServiceClientMockRecorder) MountSysfs(arg0, arg1 any, arg2 ...any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	varargs := append([]interface{}{arg0, arg1}, arg2...)
+	varargs := append([]any{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MountSysfs", reflect.TypeOf((*MockInWorkspaceServiceClient)(nil).MountSysfs), varargs...)
 }
 
 // PrepareForUserNS mocks base method.
 func (m *MockInWorkspaceServiceClient) PrepareForUserNS(arg0 context.Context, arg1 *api.PrepareForUserNSRequest, arg2 ...grpc.CallOption) (*api.PrepareForUserNSResponse, error) {
 	m.ctrl.T.Helper()
-	varargs := []interface{}{arg0, arg1}
+	varargs := []any{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
 	}
@@ -348,16 +348,16 @@ func (m *MockInWorkspaceServiceClient) PrepareForUserNS(arg0 context.Context, ar
 }
 
 // PrepareForUserNS indicates an expected call of PrepareForUserNS.
-func (mr *MockInWorkspaceServiceClientMockRecorder) PrepareForUserNS(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+func (mr *MockInWorkspaceServiceClientMockRecorder) PrepareForUserNS(arg0, arg1 any, arg2 ...any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	varargs := append([]interface{}{arg0, arg1}, arg2...)
+	varargs := append([]any{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PrepareForUserNS", reflect.TypeOf((*MockInWorkspaceServiceClient)(nil).PrepareForUserNS), varargs...)
 }
 
 // SetupPairVeths mocks base method.
 func (m *MockInWorkspaceServiceClient) SetupPairVeths(arg0 context.Context, arg1 *api.SetupPairVethsRequest, arg2 ...grpc.CallOption) (*api.SetupPairVethsResponse, error) {
 	m.ctrl.T.Helper()
-	varargs := []interface{}{arg0, arg1}
+	varargs := []any{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
 	}
@@ -368,16 +368,16 @@ func (m *MockInWorkspaceServiceClient) SetupPairVeths(arg0 context.Context, arg1
 }
 
 // SetupPairVeths indicates an expected call of SetupPairVeths.
-func (mr *MockInWorkspaceServiceClientMockRecorder) SetupPairVeths(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+func (mr *MockInWorkspaceServiceClientMockRecorder) SetupPairVeths(arg0, arg1 any, arg2 ...any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	varargs := append([]interface{}{arg0, arg1}, arg2...)
+	varargs := append([]any{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetupPairVeths", reflect.TypeOf((*MockInWorkspaceServiceClient)(nil).SetupPairVeths), varargs...)
 }
 
 // Teardown mocks base method.
 func (m *MockInWorkspaceServiceClient) Teardown(arg0 context.Context, arg1 *api.TeardownRequest, arg2 ...grpc.CallOption) (*api.TeardownResponse, error) {
 	m.ctrl.T.Helper()
-	varargs := []interface{}{arg0, arg1}
+	varargs := []any{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
 	}
@@ -388,16 +388,16 @@ func (m *MockInWorkspaceServiceClient) Teardown(arg0 context.Context, arg1 *api.
 }
 
 // Teardown indicates an expected call of Teardown.
-func (mr *MockInWorkspaceServiceClientMockRecorder) Teardown(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+func (mr *MockInWorkspaceServiceClientMockRecorder) Teardown(arg0, arg1 any, arg2 ...any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	varargs := append([]interface{}{arg0, arg1}, arg2...)
+	varargs := append([]any{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Teardown", reflect.TypeOf((*MockInWorkspaceServiceClient)(nil).Teardown), varargs...)
 }
 
 // UmountProc mocks base method.
 func (m *MockInWorkspaceServiceClient) UmountProc(arg0 context.Context, arg1 *api.UmountProcRequest, arg2 ...grpc.CallOption) (*api.UmountProcResponse, error) {
 	m.ctrl.T.Helper()
-	varargs := []interface{}{arg0, arg1}
+	varargs := []any{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
 	}
@@ -408,16 +408,16 @@ func (m *MockInWorkspaceServiceClient) UmountProc(arg0 context.Context, arg1 *ap
 }
 
 // UmountProc indicates an expected call of UmountProc.
-func (mr *MockInWorkspaceServiceClientMockRecorder) UmountProc(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+func (mr *MockInWorkspaceServiceClientMockRecorder) UmountProc(arg0, arg1 any, arg2 ...any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	varargs := append([]interface{}{arg0, arg1}, arg2...)
+	varargs := append([]any{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UmountProc", reflect.TypeOf((*MockInWorkspaceServiceClient)(nil).UmountProc), varargs...)
 }
 
 // UmountSysfs mocks base method.
 func (m *MockInWorkspaceServiceClient) UmountSysfs(arg0 context.Context, arg1 *api.UmountProcRequest, arg2 ...grpc.CallOption) (*api.UmountProcResponse, error) {
 	m.ctrl.T.Helper()
-	varargs := []interface{}{arg0, arg1}
+	varargs := []any{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
 	}
@@ -428,16 +428,16 @@ func (m *MockInWorkspaceServiceClient) UmountSysfs(arg0 context.Context, arg1 *a
 }
 
 // UmountSysfs indicates an expected call of UmountSysfs.
-func (mr *MockInWorkspaceServiceClientMockRecorder) UmountSysfs(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+func (mr *MockInWorkspaceServiceClientMockRecorder) UmountSysfs(arg0, arg1 any, arg2 ...any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	varargs := append([]interface{}{arg0, arg1}, arg2...)
+	varargs := append([]any{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UmountSysfs", reflect.TypeOf((*MockInWorkspaceServiceClient)(nil).UmountSysfs), varargs...)
 }
 
 // WorkspaceInfo mocks base method.
 func (m *MockInWorkspaceServiceClient) WorkspaceInfo(arg0 context.Context, arg1 *api.WorkspaceInfoRequest, arg2 ...grpc.CallOption) (*api.WorkspaceInfoResponse, error) {
 	m.ctrl.T.Helper()
-	varargs := []interface{}{arg0, arg1}
+	varargs := []any{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
 	}
@@ -448,16 +448,16 @@ func (m *MockInWorkspaceServiceClient) WorkspaceInfo(arg0 context.Context, arg1 
 }
 
 // WorkspaceInfo indicates an expected call of WorkspaceInfo.
-func (mr *MockInWorkspaceServiceClientMockRecorder) WorkspaceInfo(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+func (mr *MockInWorkspaceServiceClientMockRecorder) WorkspaceInfo(arg0, arg1 any, arg2 ...any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	varargs := append([]interface{}{arg0, arg1}, arg2...)
+	varargs := append([]any{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WorkspaceInfo", reflect.TypeOf((*MockInWorkspaceServiceClient)(nil).WorkspaceInfo), varargs...)
 }
 
 // WriteIDMapping mocks base method.
 func (m *MockInWorkspaceServiceClient) WriteIDMapping(arg0 context.Context, arg1 *api.WriteIDMappingRequest, arg2 ...grpc.CallOption) (*api.WriteIDMappingResponse, error) {
 	m.ctrl.T.Helper()
-	varargs := []interface{}{arg0, arg1}
+	varargs := []any{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
 	}
@@ -468,8 +468,8 @@ func (m *MockInWorkspaceServiceClient) WriteIDMapping(arg0 context.Context, arg1
 }
 
 // WriteIDMapping indicates an expected call of WriteIDMapping.
-func (mr *MockInWorkspaceServiceClientMockRecorder) WriteIDMapping(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+func (mr *MockInWorkspaceServiceClientMockRecorder) WriteIDMapping(arg0, arg1 any, arg2 ...any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	varargs := append([]interface{}{arg0, arg1}, arg2...)
+	varargs := append([]any{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WriteIDMapping", reflect.TypeOf((*MockInWorkspaceServiceClient)(nil).WriteIDMapping), varargs...)
 }

--- a/components/ws-daemon-api/go/workspace_daemon.pb.go
+++ b/components/ws-daemon-api/go/workspace_daemon.pb.go
@@ -1186,7 +1186,7 @@ func file_workspace_daemon_proto_rawDescGZIP() []byte {
 
 var file_workspace_daemon_proto_enumTypes = make([]protoimpl.EnumInfo, 1)
 var file_workspace_daemon_proto_msgTypes = make([]protoimpl.MessageInfo, 20)
-var file_workspace_daemon_proto_goTypes = []interface{}{
+var file_workspace_daemon_proto_goTypes = []any{
 	(FSShiftMethod)(0),                    // 0: iws.FSShiftMethod
 	(*PrepareForUserNSRequest)(nil),       // 1: iws.PrepareForUserNSRequest
 	(*PrepareForUserNSResponse)(nil),      // 2: iws.PrepareForUserNSResponse
@@ -1250,7 +1250,7 @@ func file_workspace_daemon_proto_init() {
 		return
 	}
 	if !protoimpl.UnsafeEnabled {
-		file_workspace_daemon_proto_msgTypes[0].Exporter = func(v interface{}, i int) interface{} {
+		file_workspace_daemon_proto_msgTypes[0].Exporter = func(v any, i int) any {
 			switch v := v.(*PrepareForUserNSRequest); i {
 			case 0:
 				return &v.state
@@ -1262,7 +1262,7 @@ func file_workspace_daemon_proto_init() {
 				return nil
 			}
 		}
-		file_workspace_daemon_proto_msgTypes[1].Exporter = func(v interface{}, i int) interface{} {
+		file_workspace_daemon_proto_msgTypes[1].Exporter = func(v any, i int) any {
 			switch v := v.(*PrepareForUserNSResponse); i {
 			case 0:
 				return &v.state
@@ -1274,7 +1274,7 @@ func file_workspace_daemon_proto_init() {
 				return nil
 			}
 		}
-		file_workspace_daemon_proto_msgTypes[2].Exporter = func(v interface{}, i int) interface{} {
+		file_workspace_daemon_proto_msgTypes[2].Exporter = func(v any, i int) any {
 			switch v := v.(*WriteIDMappingResponse); i {
 			case 0:
 				return &v.state
@@ -1286,7 +1286,7 @@ func file_workspace_daemon_proto_init() {
 				return nil
 			}
 		}
-		file_workspace_daemon_proto_msgTypes[3].Exporter = func(v interface{}, i int) interface{} {
+		file_workspace_daemon_proto_msgTypes[3].Exporter = func(v any, i int) any {
 			switch v := v.(*WriteIDMappingRequest); i {
 			case 0:
 				return &v.state
@@ -1298,7 +1298,7 @@ func file_workspace_daemon_proto_init() {
 				return nil
 			}
 		}
-		file_workspace_daemon_proto_msgTypes[4].Exporter = func(v interface{}, i int) interface{} {
+		file_workspace_daemon_proto_msgTypes[4].Exporter = func(v any, i int) any {
 			switch v := v.(*EvacuateCGroupRequest); i {
 			case 0:
 				return &v.state
@@ -1310,7 +1310,7 @@ func file_workspace_daemon_proto_init() {
 				return nil
 			}
 		}
-		file_workspace_daemon_proto_msgTypes[5].Exporter = func(v interface{}, i int) interface{} {
+		file_workspace_daemon_proto_msgTypes[5].Exporter = func(v any, i int) any {
 			switch v := v.(*EvacuateCGroupResponse); i {
 			case 0:
 				return &v.state
@@ -1322,7 +1322,7 @@ func file_workspace_daemon_proto_init() {
 				return nil
 			}
 		}
-		file_workspace_daemon_proto_msgTypes[6].Exporter = func(v interface{}, i int) interface{} {
+		file_workspace_daemon_proto_msgTypes[6].Exporter = func(v any, i int) any {
 			switch v := v.(*MountProcRequest); i {
 			case 0:
 				return &v.state
@@ -1334,7 +1334,7 @@ func file_workspace_daemon_proto_init() {
 				return nil
 			}
 		}
-		file_workspace_daemon_proto_msgTypes[7].Exporter = func(v interface{}, i int) interface{} {
+		file_workspace_daemon_proto_msgTypes[7].Exporter = func(v any, i int) any {
 			switch v := v.(*MountProcResponse); i {
 			case 0:
 				return &v.state
@@ -1346,7 +1346,7 @@ func file_workspace_daemon_proto_init() {
 				return nil
 			}
 		}
-		file_workspace_daemon_proto_msgTypes[8].Exporter = func(v interface{}, i int) interface{} {
+		file_workspace_daemon_proto_msgTypes[8].Exporter = func(v any, i int) any {
 			switch v := v.(*UmountProcRequest); i {
 			case 0:
 				return &v.state
@@ -1358,7 +1358,7 @@ func file_workspace_daemon_proto_init() {
 				return nil
 			}
 		}
-		file_workspace_daemon_proto_msgTypes[9].Exporter = func(v interface{}, i int) interface{} {
+		file_workspace_daemon_proto_msgTypes[9].Exporter = func(v any, i int) any {
 			switch v := v.(*UmountProcResponse); i {
 			case 0:
 				return &v.state
@@ -1370,7 +1370,7 @@ func file_workspace_daemon_proto_init() {
 				return nil
 			}
 		}
-		file_workspace_daemon_proto_msgTypes[10].Exporter = func(v interface{}, i int) interface{} {
+		file_workspace_daemon_proto_msgTypes[10].Exporter = func(v any, i int) any {
 			switch v := v.(*TeardownRequest); i {
 			case 0:
 				return &v.state
@@ -1382,7 +1382,7 @@ func file_workspace_daemon_proto_init() {
 				return nil
 			}
 		}
-		file_workspace_daemon_proto_msgTypes[11].Exporter = func(v interface{}, i int) interface{} {
+		file_workspace_daemon_proto_msgTypes[11].Exporter = func(v any, i int) any {
 			switch v := v.(*TeardownResponse); i {
 			case 0:
 				return &v.state
@@ -1394,7 +1394,7 @@ func file_workspace_daemon_proto_init() {
 				return nil
 			}
 		}
-		file_workspace_daemon_proto_msgTypes[12].Exporter = func(v interface{}, i int) interface{} {
+		file_workspace_daemon_proto_msgTypes[12].Exporter = func(v any, i int) any {
 			switch v := v.(*SetupPairVethsRequest); i {
 			case 0:
 				return &v.state
@@ -1406,7 +1406,7 @@ func file_workspace_daemon_proto_init() {
 				return nil
 			}
 		}
-		file_workspace_daemon_proto_msgTypes[13].Exporter = func(v interface{}, i int) interface{} {
+		file_workspace_daemon_proto_msgTypes[13].Exporter = func(v any, i int) any {
 			switch v := v.(*SetupPairVethsResponse); i {
 			case 0:
 				return &v.state
@@ -1418,7 +1418,7 @@ func file_workspace_daemon_proto_init() {
 				return nil
 			}
 		}
-		file_workspace_daemon_proto_msgTypes[14].Exporter = func(v interface{}, i int) interface{} {
+		file_workspace_daemon_proto_msgTypes[14].Exporter = func(v any, i int) any {
 			switch v := v.(*WorkspaceInfoRequest); i {
 			case 0:
 				return &v.state
@@ -1430,7 +1430,7 @@ func file_workspace_daemon_proto_init() {
 				return nil
 			}
 		}
-		file_workspace_daemon_proto_msgTypes[15].Exporter = func(v interface{}, i int) interface{} {
+		file_workspace_daemon_proto_msgTypes[15].Exporter = func(v any, i int) any {
 			switch v := v.(*WorkspaceInfoResponse); i {
 			case 0:
 				return &v.state
@@ -1442,7 +1442,7 @@ func file_workspace_daemon_proto_init() {
 				return nil
 			}
 		}
-		file_workspace_daemon_proto_msgTypes[16].Exporter = func(v interface{}, i int) interface{} {
+		file_workspace_daemon_proto_msgTypes[16].Exporter = func(v any, i int) any {
 			switch v := v.(*Resources); i {
 			case 0:
 				return &v.state
@@ -1454,7 +1454,7 @@ func file_workspace_daemon_proto_init() {
 				return nil
 			}
 		}
-		file_workspace_daemon_proto_msgTypes[17].Exporter = func(v interface{}, i int) interface{} {
+		file_workspace_daemon_proto_msgTypes[17].Exporter = func(v any, i int) any {
 			switch v := v.(*Cpu); i {
 			case 0:
 				return &v.state
@@ -1466,7 +1466,7 @@ func file_workspace_daemon_proto_init() {
 				return nil
 			}
 		}
-		file_workspace_daemon_proto_msgTypes[18].Exporter = func(v interface{}, i int) interface{} {
+		file_workspace_daemon_proto_msgTypes[18].Exporter = func(v any, i int) any {
 			switch v := v.(*Memory); i {
 			case 0:
 				return &v.state
@@ -1478,7 +1478,7 @@ func file_workspace_daemon_proto_init() {
 				return nil
 			}
 		}
-		file_workspace_daemon_proto_msgTypes[19].Exporter = func(v interface{}, i int) interface{} {
+		file_workspace_daemon_proto_msgTypes[19].Exporter = func(v any, i int) any {
 			switch v := v.(*WriteIDMappingRequest_Mapping); i {
 			case 0:
 				return &v.state

--- a/components/ws-daemon-api/go/workspace_daemon_grpc.pb.go
+++ b/components/ws-daemon-api/go/workspace_daemon_grpc.pb.go
@@ -254,7 +254,7 @@ func RegisterInWorkspaceServiceServer(s grpc.ServiceRegistrar, srv InWorkspaceSe
 	s.RegisterService(&InWorkspaceService_ServiceDesc, srv)
 }
 
-func _InWorkspaceService_PrepareForUserNS_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+func _InWorkspaceService_PrepareForUserNS_Handler(srv any, ctx context.Context, dec func(any) error, interceptor grpc.UnaryServerInterceptor) (any, error) {
 	in := new(PrepareForUserNSRequest)
 	if err := dec(in); err != nil {
 		return nil, err
@@ -266,13 +266,13 @@ func _InWorkspaceService_PrepareForUserNS_Handler(srv interface{}, ctx context.C
 		Server:     srv,
 		FullMethod: "/iws.InWorkspaceService/PrepareForUserNS",
 	}
-	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+	handler := func(ctx context.Context, req any) (any, error) {
 		return srv.(InWorkspaceServiceServer).PrepareForUserNS(ctx, req.(*PrepareForUserNSRequest))
 	}
 	return interceptor(ctx, in, info, handler)
 }
 
-func _InWorkspaceService_WriteIDMapping_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+func _InWorkspaceService_WriteIDMapping_Handler(srv any, ctx context.Context, dec func(any) error, interceptor grpc.UnaryServerInterceptor) (any, error) {
 	in := new(WriteIDMappingRequest)
 	if err := dec(in); err != nil {
 		return nil, err
@@ -284,13 +284,13 @@ func _InWorkspaceService_WriteIDMapping_Handler(srv interface{}, ctx context.Con
 		Server:     srv,
 		FullMethod: "/iws.InWorkspaceService/WriteIDMapping",
 	}
-	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+	handler := func(ctx context.Context, req any) (any, error) {
 		return srv.(InWorkspaceServiceServer).WriteIDMapping(ctx, req.(*WriteIDMappingRequest))
 	}
 	return interceptor(ctx, in, info, handler)
 }
 
-func _InWorkspaceService_EvacuateCGroup_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+func _InWorkspaceService_EvacuateCGroup_Handler(srv any, ctx context.Context, dec func(any) error, interceptor grpc.UnaryServerInterceptor) (any, error) {
 	in := new(EvacuateCGroupRequest)
 	if err := dec(in); err != nil {
 		return nil, err
@@ -302,13 +302,13 @@ func _InWorkspaceService_EvacuateCGroup_Handler(srv interface{}, ctx context.Con
 		Server:     srv,
 		FullMethod: "/iws.InWorkspaceService/EvacuateCGroup",
 	}
-	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+	handler := func(ctx context.Context, req any) (any, error) {
 		return srv.(InWorkspaceServiceServer).EvacuateCGroup(ctx, req.(*EvacuateCGroupRequest))
 	}
 	return interceptor(ctx, in, info, handler)
 }
 
-func _InWorkspaceService_MountProc_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+func _InWorkspaceService_MountProc_Handler(srv any, ctx context.Context, dec func(any) error, interceptor grpc.UnaryServerInterceptor) (any, error) {
 	in := new(MountProcRequest)
 	if err := dec(in); err != nil {
 		return nil, err
@@ -320,13 +320,13 @@ func _InWorkspaceService_MountProc_Handler(srv interface{}, ctx context.Context,
 		Server:     srv,
 		FullMethod: "/iws.InWorkspaceService/MountProc",
 	}
-	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+	handler := func(ctx context.Context, req any) (any, error) {
 		return srv.(InWorkspaceServiceServer).MountProc(ctx, req.(*MountProcRequest))
 	}
 	return interceptor(ctx, in, info, handler)
 }
 
-func _InWorkspaceService_UmountProc_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+func _InWorkspaceService_UmountProc_Handler(srv any, ctx context.Context, dec func(any) error, interceptor grpc.UnaryServerInterceptor) (any, error) {
 	in := new(UmountProcRequest)
 	if err := dec(in); err != nil {
 		return nil, err
@@ -338,13 +338,13 @@ func _InWorkspaceService_UmountProc_Handler(srv interface{}, ctx context.Context
 		Server:     srv,
 		FullMethod: "/iws.InWorkspaceService/UmountProc",
 	}
-	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+	handler := func(ctx context.Context, req any) (any, error) {
 		return srv.(InWorkspaceServiceServer).UmountProc(ctx, req.(*UmountProcRequest))
 	}
 	return interceptor(ctx, in, info, handler)
 }
 
-func _InWorkspaceService_MountSysfs_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+func _InWorkspaceService_MountSysfs_Handler(srv any, ctx context.Context, dec func(any) error, interceptor grpc.UnaryServerInterceptor) (any, error) {
 	in := new(MountProcRequest)
 	if err := dec(in); err != nil {
 		return nil, err
@@ -356,13 +356,13 @@ func _InWorkspaceService_MountSysfs_Handler(srv interface{}, ctx context.Context
 		Server:     srv,
 		FullMethod: "/iws.InWorkspaceService/MountSysfs",
 	}
-	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+	handler := func(ctx context.Context, req any) (any, error) {
 		return srv.(InWorkspaceServiceServer).MountSysfs(ctx, req.(*MountProcRequest))
 	}
 	return interceptor(ctx, in, info, handler)
 }
 
-func _InWorkspaceService_UmountSysfs_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+func _InWorkspaceService_UmountSysfs_Handler(srv any, ctx context.Context, dec func(any) error, interceptor grpc.UnaryServerInterceptor) (any, error) {
 	in := new(UmountProcRequest)
 	if err := dec(in); err != nil {
 		return nil, err
@@ -374,13 +374,13 @@ func _InWorkspaceService_UmountSysfs_Handler(srv interface{}, ctx context.Contex
 		Server:     srv,
 		FullMethod: "/iws.InWorkspaceService/UmountSysfs",
 	}
-	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+	handler := func(ctx context.Context, req any) (any, error) {
 		return srv.(InWorkspaceServiceServer).UmountSysfs(ctx, req.(*UmountProcRequest))
 	}
 	return interceptor(ctx, in, info, handler)
 }
 
-func _InWorkspaceService_Teardown_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+func _InWorkspaceService_Teardown_Handler(srv any, ctx context.Context, dec func(any) error, interceptor grpc.UnaryServerInterceptor) (any, error) {
 	in := new(TeardownRequest)
 	if err := dec(in); err != nil {
 		return nil, err
@@ -392,13 +392,13 @@ func _InWorkspaceService_Teardown_Handler(srv interface{}, ctx context.Context, 
 		Server:     srv,
 		FullMethod: "/iws.InWorkspaceService/Teardown",
 	}
-	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+	handler := func(ctx context.Context, req any) (any, error) {
 		return srv.(InWorkspaceServiceServer).Teardown(ctx, req.(*TeardownRequest))
 	}
 	return interceptor(ctx, in, info, handler)
 }
 
-func _InWorkspaceService_SetupPairVeths_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+func _InWorkspaceService_SetupPairVeths_Handler(srv any, ctx context.Context, dec func(any) error, interceptor grpc.UnaryServerInterceptor) (any, error) {
 	in := new(SetupPairVethsRequest)
 	if err := dec(in); err != nil {
 		return nil, err
@@ -410,13 +410,13 @@ func _InWorkspaceService_SetupPairVeths_Handler(srv interface{}, ctx context.Con
 		Server:     srv,
 		FullMethod: "/iws.InWorkspaceService/SetupPairVeths",
 	}
-	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+	handler := func(ctx context.Context, req any) (any, error) {
 		return srv.(InWorkspaceServiceServer).SetupPairVeths(ctx, req.(*SetupPairVethsRequest))
 	}
 	return interceptor(ctx, in, info, handler)
 }
 
-func _InWorkspaceService_WorkspaceInfo_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+func _InWorkspaceService_WorkspaceInfo_Handler(srv any, ctx context.Context, dec func(any) error, interceptor grpc.UnaryServerInterceptor) (any, error) {
 	in := new(WorkspaceInfoRequest)
 	if err := dec(in); err != nil {
 		return nil, err
@@ -428,7 +428,7 @@ func _InWorkspaceService_WorkspaceInfo_Handler(srv interface{}, ctx context.Cont
 		Server:     srv,
 		FullMethod: "/iws.InWorkspaceService/WorkspaceInfo",
 	}
-	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+	handler := func(ctx context.Context, req any) (any, error) {
 		return srv.(InWorkspaceServiceServer).WorkspaceInfo(ctx, req.(*WorkspaceInfoRequest))
 	}
 	return interceptor(ctx, in, info, handler)
@@ -540,7 +540,7 @@ func RegisterWorkspaceInfoServiceServer(s grpc.ServiceRegistrar, srv WorkspaceIn
 	s.RegisterService(&WorkspaceInfoService_ServiceDesc, srv)
 }
 
-func _WorkspaceInfoService_WorkspaceInfo_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+func _WorkspaceInfoService_WorkspaceInfo_Handler(srv any, ctx context.Context, dec func(any) error, interceptor grpc.UnaryServerInterceptor) (any, error) {
 	in := new(WorkspaceInfoRequest)
 	if err := dec(in); err != nil {
 		return nil, err
@@ -552,7 +552,7 @@ func _WorkspaceInfoService_WorkspaceInfo_Handler(srv interface{}, ctx context.Co
 		Server:     srv,
 		FullMethod: "/iws.WorkspaceInfoService/WorkspaceInfo",
 	}
-	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+	handler := func(ctx context.Context, req any) (any, error) {
 		return srv.(WorkspaceInfoServiceServer).WorkspaceInfo(ctx, req.(*WorkspaceInfoRequest))
 	}
 	return interceptor(ctx, in, info, handler)

--- a/components/ws-daemon/pkg/container/containerd.go
+++ b/components/ws-daemon/pkg/container/containerd.go
@@ -150,7 +150,7 @@ func (s *Containerd) start() {
 	}
 }
 
-func (s *Containerd) handleContainerdEvent(ev interface{}) {
+func (s *Containerd) handleContainerdEvent(ev any) {
 	switch evt := ev.(type) {
 	case *events.ContainerCreate:
 		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)

--- a/components/ws-daemon/pkg/content/initializer.go
+++ b/components/ws-daemon/pkg/content/initializer.go
@@ -55,7 +55,7 @@ type OWI struct {
 	InstanceID  string
 }
 
-func (o OWI) Fields() map[string]interface{} {
+func (o OWI) Fields() map[string]any {
 	return log.OWI(o.Owner, o.WorkspaceID, o.InstanceID)
 }
 
@@ -451,5 +451,5 @@ type msgInitContent struct {
 	IDMappings    []archive.IDMapping
 
 	TraceInfo string
-	OWI       map[string]interface{}
+	OWI       map[string]any
 }

--- a/components/ws-daemon/pkg/content/service.go
+++ b/components/ws-daemon/pkg/content/service.go
@@ -940,6 +940,6 @@ func (c *cannotCancelContext) Err() error {
 	return err
 }
 
-func (c *cannotCancelContext) Value(key interface{}) interface{} {
+func (c *cannotCancelContext) Value(key any) any {
 	return c.Delegate.Value(key)
 }

--- a/components/ws-daemon/pkg/dispatch/dispatch.go
+++ b/components/ws-daemon/pkg/dispatch/dispatch.go
@@ -104,7 +104,7 @@ func (d *Dispatch) Start() error {
 	ifac := informers.NewSharedInformerFactoryWithOptions(d.Kubernetes, podInformerResyncInterval, informers.WithNamespace(d.KubernetesNamespace))
 	podInformer := ifac.Core().V1().Pods().Informer()
 	podInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{
-		UpdateFunc: func(oldObj, newObj interface{}) {
+		UpdateFunc: func(oldObj, newObj any) {
 			oldPod, ok := oldObj.(*corev1.Pod)
 			if !ok {
 				return
@@ -116,7 +116,7 @@ func (d *Dispatch) Start() error {
 
 			d.handlePodUpdate(oldPod, newPod)
 		},
-		DeleteFunc: func(obj interface{}) {
+		DeleteFunc: func(obj any) {
 			pod, ok := obj.(*corev1.Pod)
 			if !ok {
 				return

--- a/components/ws-daemon/pkg/internal/session/store.go
+++ b/components/ws-daemon/pkg/internal/session/store.go
@@ -119,7 +119,7 @@ func (s *Store) NewWorkspace(ctx context.Context, instanceID, location string, c
 	}
 	res.state = WorkspaceInitializing
 	if res.NonPersistentAttrs == nil {
-		res.NonPersistentAttrs = make(map[string]interface{})
+		res.NonPersistentAttrs = make(map[string]any)
 	}
 	res.operatingCondition = sync.NewCond(&sync.Mutex{})
 	res.store = s

--- a/components/ws-daemon/pkg/internal/session/workspace.go
+++ b/components/ws-daemon/pkg/internal/session/workspace.go
@@ -75,7 +75,7 @@ type Workspace struct {
 
 	XFSProjectID int `json:"xfsProjectID"`
 
-	NonPersistentAttrs map[string]interface{} `json:"-"`
+	NonPersistentAttrs map[string]any `json:"-"`
 
 	store              *Store
 	state              WorkspaceState
@@ -379,7 +379,7 @@ func loadWorkspace(ctx context.Context, path string) (sess *Workspace, err error
 	}
 
 	res := p.Workspace
-	res.NonPersistentAttrs = make(map[string]interface{})
+	res.NonPersistentAttrs = make(map[string]any)
 	res.state = p.State
 	res.operatingCondition = sync.NewCond(&sync.Mutex{})
 

--- a/components/ws-daemon/pkg/iws/iws.go
+++ b/components/ws-daemon/pkg/iws/iws.go
@@ -745,7 +745,7 @@ func moveMount(instanceID string, targetPid int, source, target string) error {
 // Errors are logged instead of returned.
 // This is useful for when we've moved the mount (which we've done with OPEN_TREE_CLONE), we'll
 // need to unmount the mask mounts again to not leave them dangling.
-func cleanupMaskedMount(owi map[string]interface{}, base string, paths []string) {
+func cleanupMaskedMount(owi map[string]any, base string, paths []string) {
 	for _, mask := range paths {
 		// Note: if errors happen while unmounting or removing the masks this does not mean
 		//       that the final unmount won't happen. I.e. we can ignore those errors here
@@ -1223,7 +1223,7 @@ func (rli ratelimitingInterceptor) UnaryInterceptor() grpc.UnaryServerIntercepto
 		mu   sync.Mutex
 		used = make(map[string]struct{})
 	)
-	return func(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (resp interface{}, err error) {
+	return func(ctx context.Context, req any, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (resp any, err error) {
 		limit, ok := rli[info.FullMethod]
 		if ok {
 			if limit.UseOnce {

--- a/components/ws-daemon/pkg/iws/uidmap.go
+++ b/components/ws-daemon/pkg/iws/uidmap.go
@@ -65,7 +65,7 @@ func (m *Uidmapper) HandleUIDMappingRequest(ctx context.Context, req *api.WriteI
 		return err
 	}
 
-	log := log.WithFields(map[string]interface{}{
+	log := log.WithFields(map[string]any{
 		"req":         string(reqjson),
 		"containerID": containerID,
 		"instanceId":  instanceID,

--- a/components/ws-daemon/pkg/quota/size.go
+++ b/components/ws-daemon/pkg/quota/size.go
@@ -98,7 +98,7 @@ func (s Size) MarshalJSON() ([]byte, error) {
 
 // UnmarshalJSON unmarshals a duration from JSON
 func (s *Size) UnmarshalJSON(b []byte) error {
-	var v interface{}
+	var v any
 	if err := json.Unmarshal(b, &v); err != nil {
 		return err
 	}

--- a/components/ws-manager-api/go/config/config.go
+++ b/components/ws-manager-api/go/config/config.go
@@ -244,7 +244,7 @@ func (c *Configuration) Validate() error {
 	return err
 }
 
-var validPodTemplate = ozzo.By(func(o interface{}) error {
+var validPodTemplate = ozzo.By(func(o any) error {
 	s, ok := o.(string)
 	if !ok {
 		return xerrors.Errorf("field should be string")
@@ -254,7 +254,7 @@ var validPodTemplate = ozzo.By(func(o interface{}) error {
 	return err
 })
 
-var validWorkspaceURLTemplate = ozzo.By(func(o interface{}) error {
+var validWorkspaceURLTemplate = ozzo.By(func(o any) error {
 	s, ok := o.(string)
 	if !ok {
 		return xerrors.Errorf("field should be string")
@@ -302,7 +302,7 @@ func (c *ContainerConfiguration) Validate() error {
 	)
 }
 
-var validResourceRequestConfig = ozzo.By(func(o interface{}) error {
+var validResourceRequestConfig = ozzo.By(func(o any) error {
 	rc, ok := o.(*ResourceRequestConfiguration)
 	if !ok {
 		return xerrors.Errorf("can only validate ResourceRequestConfiguration")
@@ -337,7 +337,7 @@ var validResourceRequestConfig = ozzo.By(func(o interface{}) error {
 	return nil
 })
 
-var validResourceLimitConfig = ozzo.By(func(o interface{}) error {
+var validResourceLimitConfig = ozzo.By(func(o any) error {
 	rc, ok := o.(*ResourceLimitConfiguration)
 	if !ok {
 		return xerrors.Errorf("can only validate ResourceLimitConfiguration")

--- a/components/ws-manager-api/go/core.pb.go
+++ b/components/ws-manager-api/go/core.pb.go
@@ -3791,7 +3791,7 @@ func file_core_proto_rawDescGZIP() []byte {
 
 var file_core_proto_enumTypes = make([]protoimpl.EnumInfo, 7)
 var file_core_proto_msgTypes = make([]protoimpl.MessageInfo, 48)
-var file_core_proto_goTypes = []interface{}{
+var file_core_proto_goTypes = []any{
 	(StopWorkspacePolicy)(0),                 // 0: wsman.StopWorkspacePolicy
 	(AdmissionLevel)(0),                      // 1: wsman.AdmissionLevel
 	(PortVisibility)(0),                      // 2: wsman.PortVisibility
@@ -3939,7 +3939,7 @@ func file_core_proto_init() {
 		return
 	}
 	if !protoimpl.UnsafeEnabled {
-		file_core_proto_msgTypes[0].Exporter = func(v interface{}, i int) interface{} {
+		file_core_proto_msgTypes[0].Exporter = func(v any, i int) any {
 			switch v := v.(*MetadataFilter); i {
 			case 0:
 				return &v.state
@@ -3951,7 +3951,7 @@ func file_core_proto_init() {
 				return nil
 			}
 		}
-		file_core_proto_msgTypes[1].Exporter = func(v interface{}, i int) interface{} {
+		file_core_proto_msgTypes[1].Exporter = func(v any, i int) any {
 			switch v := v.(*GetWorkspacesRequest); i {
 			case 0:
 				return &v.state
@@ -3963,7 +3963,7 @@ func file_core_proto_init() {
 				return nil
 			}
 		}
-		file_core_proto_msgTypes[2].Exporter = func(v interface{}, i int) interface{} {
+		file_core_proto_msgTypes[2].Exporter = func(v any, i int) any {
 			switch v := v.(*GetWorkspacesResponse); i {
 			case 0:
 				return &v.state
@@ -3975,7 +3975,7 @@ func file_core_proto_init() {
 				return nil
 			}
 		}
-		file_core_proto_msgTypes[3].Exporter = func(v interface{}, i int) interface{} {
+		file_core_proto_msgTypes[3].Exporter = func(v any, i int) any {
 			switch v := v.(*StartWorkspaceRequest); i {
 			case 0:
 				return &v.state
@@ -3987,7 +3987,7 @@ func file_core_proto_init() {
 				return nil
 			}
 		}
-		file_core_proto_msgTypes[4].Exporter = func(v interface{}, i int) interface{} {
+		file_core_proto_msgTypes[4].Exporter = func(v any, i int) any {
 			switch v := v.(*StartWorkspaceResponse); i {
 			case 0:
 				return &v.state
@@ -3999,7 +3999,7 @@ func file_core_proto_init() {
 				return nil
 			}
 		}
-		file_core_proto_msgTypes[5].Exporter = func(v interface{}, i int) interface{} {
+		file_core_proto_msgTypes[5].Exporter = func(v any, i int) any {
 			switch v := v.(*StopWorkspaceRequest); i {
 			case 0:
 				return &v.state
@@ -4011,7 +4011,7 @@ func file_core_proto_init() {
 				return nil
 			}
 		}
-		file_core_proto_msgTypes[6].Exporter = func(v interface{}, i int) interface{} {
+		file_core_proto_msgTypes[6].Exporter = func(v any, i int) any {
 			switch v := v.(*StopWorkspaceResponse); i {
 			case 0:
 				return &v.state
@@ -4023,7 +4023,7 @@ func file_core_proto_init() {
 				return nil
 			}
 		}
-		file_core_proto_msgTypes[7].Exporter = func(v interface{}, i int) interface{} {
+		file_core_proto_msgTypes[7].Exporter = func(v any, i int) any {
 			switch v := v.(*DescribeWorkspaceRequest); i {
 			case 0:
 				return &v.state
@@ -4035,7 +4035,7 @@ func file_core_proto_init() {
 				return nil
 			}
 		}
-		file_core_proto_msgTypes[8].Exporter = func(v interface{}, i int) interface{} {
+		file_core_proto_msgTypes[8].Exporter = func(v any, i int) any {
 			switch v := v.(*DescribeWorkspaceResponse); i {
 			case 0:
 				return &v.state
@@ -4047,7 +4047,7 @@ func file_core_proto_init() {
 				return nil
 			}
 		}
-		file_core_proto_msgTypes[9].Exporter = func(v interface{}, i int) interface{} {
+		file_core_proto_msgTypes[9].Exporter = func(v any, i int) any {
 			switch v := v.(*SubscribeRequest); i {
 			case 0:
 				return &v.state
@@ -4059,7 +4059,7 @@ func file_core_proto_init() {
 				return nil
 			}
 		}
-		file_core_proto_msgTypes[10].Exporter = func(v interface{}, i int) interface{} {
+		file_core_proto_msgTypes[10].Exporter = func(v any, i int) any {
 			switch v := v.(*SubscribeResponse); i {
 			case 0:
 				return &v.state
@@ -4071,7 +4071,7 @@ func file_core_proto_init() {
 				return nil
 			}
 		}
-		file_core_proto_msgTypes[11].Exporter = func(v interface{}, i int) interface{} {
+		file_core_proto_msgTypes[11].Exporter = func(v any, i int) any {
 			switch v := v.(*MarkActiveRequest); i {
 			case 0:
 				return &v.state
@@ -4083,7 +4083,7 @@ func file_core_proto_init() {
 				return nil
 			}
 		}
-		file_core_proto_msgTypes[12].Exporter = func(v interface{}, i int) interface{} {
+		file_core_proto_msgTypes[12].Exporter = func(v any, i int) any {
 			switch v := v.(*MarkActiveResponse); i {
 			case 0:
 				return &v.state
@@ -4095,7 +4095,7 @@ func file_core_proto_init() {
 				return nil
 			}
 		}
-		file_core_proto_msgTypes[13].Exporter = func(v interface{}, i int) interface{} {
+		file_core_proto_msgTypes[13].Exporter = func(v any, i int) any {
 			switch v := v.(*SetTimeoutRequest); i {
 			case 0:
 				return &v.state
@@ -4107,7 +4107,7 @@ func file_core_proto_init() {
 				return nil
 			}
 		}
-		file_core_proto_msgTypes[14].Exporter = func(v interface{}, i int) interface{} {
+		file_core_proto_msgTypes[14].Exporter = func(v any, i int) any {
 			switch v := v.(*SetTimeoutResponse); i {
 			case 0:
 				return &v.state
@@ -4119,7 +4119,7 @@ func file_core_proto_init() {
 				return nil
 			}
 		}
-		file_core_proto_msgTypes[15].Exporter = func(v interface{}, i int) interface{} {
+		file_core_proto_msgTypes[15].Exporter = func(v any, i int) any {
 			switch v := v.(*ControlPortRequest); i {
 			case 0:
 				return &v.state
@@ -4131,7 +4131,7 @@ func file_core_proto_init() {
 				return nil
 			}
 		}
-		file_core_proto_msgTypes[16].Exporter = func(v interface{}, i int) interface{} {
+		file_core_proto_msgTypes[16].Exporter = func(v any, i int) any {
 			switch v := v.(*ControlPortResponse); i {
 			case 0:
 				return &v.state
@@ -4143,7 +4143,7 @@ func file_core_proto_init() {
 				return nil
 			}
 		}
-		file_core_proto_msgTypes[17].Exporter = func(v interface{}, i int) interface{} {
+		file_core_proto_msgTypes[17].Exporter = func(v any, i int) any {
 			switch v := v.(*TakeSnapshotRequest); i {
 			case 0:
 				return &v.state
@@ -4155,7 +4155,7 @@ func file_core_proto_init() {
 				return nil
 			}
 		}
-		file_core_proto_msgTypes[18].Exporter = func(v interface{}, i int) interface{} {
+		file_core_proto_msgTypes[18].Exporter = func(v any, i int) any {
 			switch v := v.(*TakeSnapshotResponse); i {
 			case 0:
 				return &v.state
@@ -4167,7 +4167,7 @@ func file_core_proto_init() {
 				return nil
 			}
 		}
-		file_core_proto_msgTypes[19].Exporter = func(v interface{}, i int) interface{} {
+		file_core_proto_msgTypes[19].Exporter = func(v any, i int) any {
 			switch v := v.(*ControlAdmissionRequest); i {
 			case 0:
 				return &v.state
@@ -4179,7 +4179,7 @@ func file_core_proto_init() {
 				return nil
 			}
 		}
-		file_core_proto_msgTypes[20].Exporter = func(v interface{}, i int) interface{} {
+		file_core_proto_msgTypes[20].Exporter = func(v any, i int) any {
 			switch v := v.(*ControlAdmissionResponse); i {
 			case 0:
 				return &v.state
@@ -4191,7 +4191,7 @@ func file_core_proto_init() {
 				return nil
 			}
 		}
-		file_core_proto_msgTypes[21].Exporter = func(v interface{}, i int) interface{} {
+		file_core_proto_msgTypes[21].Exporter = func(v any, i int) any {
 			switch v := v.(*DeleteVolumeSnapshotRequest); i {
 			case 0:
 				return &v.state
@@ -4203,7 +4203,7 @@ func file_core_proto_init() {
 				return nil
 			}
 		}
-		file_core_proto_msgTypes[22].Exporter = func(v interface{}, i int) interface{} {
+		file_core_proto_msgTypes[22].Exporter = func(v any, i int) any {
 			switch v := v.(*DeleteVolumeSnapshotResponse); i {
 			case 0:
 				return &v.state
@@ -4215,7 +4215,7 @@ func file_core_proto_init() {
 				return nil
 			}
 		}
-		file_core_proto_msgTypes[23].Exporter = func(v interface{}, i int) interface{} {
+		file_core_proto_msgTypes[23].Exporter = func(v any, i int) any {
 			switch v := v.(*BackupWorkspaceRequest); i {
 			case 0:
 				return &v.state
@@ -4227,7 +4227,7 @@ func file_core_proto_init() {
 				return nil
 			}
 		}
-		file_core_proto_msgTypes[24].Exporter = func(v interface{}, i int) interface{} {
+		file_core_proto_msgTypes[24].Exporter = func(v any, i int) any {
 			switch v := v.(*BackupWorkspaceResponse); i {
 			case 0:
 				return &v.state
@@ -4239,7 +4239,7 @@ func file_core_proto_init() {
 				return nil
 			}
 		}
-		file_core_proto_msgTypes[25].Exporter = func(v interface{}, i int) interface{} {
+		file_core_proto_msgTypes[25].Exporter = func(v any, i int) any {
 			switch v := v.(*UpdateSSHKeyRequest); i {
 			case 0:
 				return &v.state
@@ -4251,7 +4251,7 @@ func file_core_proto_init() {
 				return nil
 			}
 		}
-		file_core_proto_msgTypes[26].Exporter = func(v interface{}, i int) interface{} {
+		file_core_proto_msgTypes[26].Exporter = func(v any, i int) any {
 			switch v := v.(*UpdateSSHKeyResponse); i {
 			case 0:
 				return &v.state
@@ -4263,7 +4263,7 @@ func file_core_proto_init() {
 				return nil
 			}
 		}
-		file_core_proto_msgTypes[27].Exporter = func(v interface{}, i int) interface{} {
+		file_core_proto_msgTypes[27].Exporter = func(v any, i int) any {
 			switch v := v.(*WorkspaceStatus); i {
 			case 0:
 				return &v.state
@@ -4275,7 +4275,7 @@ func file_core_proto_init() {
 				return nil
 			}
 		}
-		file_core_proto_msgTypes[28].Exporter = func(v interface{}, i int) interface{} {
+		file_core_proto_msgTypes[28].Exporter = func(v any, i int) any {
 			switch v := v.(*IDEImage); i {
 			case 0:
 				return &v.state
@@ -4287,7 +4287,7 @@ func file_core_proto_init() {
 				return nil
 			}
 		}
-		file_core_proto_msgTypes[29].Exporter = func(v interface{}, i int) interface{} {
+		file_core_proto_msgTypes[29].Exporter = func(v any, i int) any {
 			switch v := v.(*WorkspaceSpec); i {
 			case 0:
 				return &v.state
@@ -4299,7 +4299,7 @@ func file_core_proto_init() {
 				return nil
 			}
 		}
-		file_core_proto_msgTypes[30].Exporter = func(v interface{}, i int) interface{} {
+		file_core_proto_msgTypes[30].Exporter = func(v any, i int) any {
 			switch v := v.(*PortSpec); i {
 			case 0:
 				return &v.state
@@ -4311,7 +4311,7 @@ func file_core_proto_init() {
 				return nil
 			}
 		}
-		file_core_proto_msgTypes[31].Exporter = func(v interface{}, i int) interface{} {
+		file_core_proto_msgTypes[31].Exporter = func(v any, i int) any {
 			switch v := v.(*VolumeSnapshotInfo); i {
 			case 0:
 				return &v.state
@@ -4323,7 +4323,7 @@ func file_core_proto_init() {
 				return nil
 			}
 		}
-		file_core_proto_msgTypes[32].Exporter = func(v interface{}, i int) interface{} {
+		file_core_proto_msgTypes[32].Exporter = func(v any, i int) any {
 			switch v := v.(*WorkspaceConditions); i {
 			case 0:
 				return &v.state
@@ -4335,7 +4335,7 @@ func file_core_proto_init() {
 				return nil
 			}
 		}
-		file_core_proto_msgTypes[33].Exporter = func(v interface{}, i int) interface{} {
+		file_core_proto_msgTypes[33].Exporter = func(v any, i int) any {
 			switch v := v.(*WorkspaceMetadata); i {
 			case 0:
 				return &v.state
@@ -4347,7 +4347,7 @@ func file_core_proto_init() {
 				return nil
 			}
 		}
-		file_core_proto_msgTypes[34].Exporter = func(v interface{}, i int) interface{} {
+		file_core_proto_msgTypes[34].Exporter = func(v any, i int) any {
 			switch v := v.(*WorkspaceRuntimeInfo); i {
 			case 0:
 				return &v.state
@@ -4359,7 +4359,7 @@ func file_core_proto_init() {
 				return nil
 			}
 		}
-		file_core_proto_msgTypes[35].Exporter = func(v interface{}, i int) interface{} {
+		file_core_proto_msgTypes[35].Exporter = func(v any, i int) any {
 			switch v := v.(*WorkspaceAuthentication); i {
 			case 0:
 				return &v.state
@@ -4371,7 +4371,7 @@ func file_core_proto_init() {
 				return nil
 			}
 		}
-		file_core_proto_msgTypes[36].Exporter = func(v interface{}, i int) interface{} {
+		file_core_proto_msgTypes[36].Exporter = func(v any, i int) any {
 			switch v := v.(*StartWorkspaceSpec); i {
 			case 0:
 				return &v.state
@@ -4383,7 +4383,7 @@ func file_core_proto_init() {
 				return nil
 			}
 		}
-		file_core_proto_msgTypes[37].Exporter = func(v interface{}, i int) interface{} {
+		file_core_proto_msgTypes[37].Exporter = func(v any, i int) any {
 			switch v := v.(*GitSpec); i {
 			case 0:
 				return &v.state
@@ -4395,7 +4395,7 @@ func file_core_proto_init() {
 				return nil
 			}
 		}
-		file_core_proto_msgTypes[38].Exporter = func(v interface{}, i int) interface{} {
+		file_core_proto_msgTypes[38].Exporter = func(v any, i int) any {
 			switch v := v.(*EnvironmentVariable); i {
 			case 0:
 				return &v.state
@@ -4407,7 +4407,7 @@ func file_core_proto_init() {
 				return nil
 			}
 		}
-		file_core_proto_msgTypes[39].Exporter = func(v interface{}, i int) interface{} {
+		file_core_proto_msgTypes[39].Exporter = func(v any, i int) any {
 			switch v := v.(*ExposedPorts); i {
 			case 0:
 				return &v.state
@@ -4419,7 +4419,7 @@ func file_core_proto_init() {
 				return nil
 			}
 		}
-		file_core_proto_msgTypes[40].Exporter = func(v interface{}, i int) interface{} {
+		file_core_proto_msgTypes[40].Exporter = func(v any, i int) any {
 			switch v := v.(*SSHPublicKeys); i {
 			case 0:
 				return &v.state
@@ -4431,7 +4431,7 @@ func file_core_proto_init() {
 				return nil
 			}
 		}
-		file_core_proto_msgTypes[41].Exporter = func(v interface{}, i int) interface{} {
+		file_core_proto_msgTypes[41].Exporter = func(v any, i int) any {
 			switch v := v.(*DescribeClusterRequest); i {
 			case 0:
 				return &v.state
@@ -4443,7 +4443,7 @@ func file_core_proto_init() {
 				return nil
 			}
 		}
-		file_core_proto_msgTypes[42].Exporter = func(v interface{}, i int) interface{} {
+		file_core_proto_msgTypes[42].Exporter = func(v any, i int) any {
 			switch v := v.(*DescribeClusterResponse); i {
 			case 0:
 				return &v.state
@@ -4455,7 +4455,7 @@ func file_core_proto_init() {
 				return nil
 			}
 		}
-		file_core_proto_msgTypes[43].Exporter = func(v interface{}, i int) interface{} {
+		file_core_proto_msgTypes[43].Exporter = func(v any, i int) any {
 			switch v := v.(*WorkspaceClass); i {
 			case 0:
 				return &v.state
@@ -4467,7 +4467,7 @@ func file_core_proto_init() {
 				return nil
 			}
 		}
-		file_core_proto_msgTypes[47].Exporter = func(v interface{}, i int) interface{} {
+		file_core_proto_msgTypes[47].Exporter = func(v any, i int) any {
 			switch v := v.(*EnvironmentVariable_SecretKeyRef); i {
 			case 0:
 				return &v.state
@@ -4480,7 +4480,7 @@ func file_core_proto_init() {
 			}
 		}
 	}
-	file_core_proto_msgTypes[33].OneofWrappers = []interface{}{}
+	file_core_proto_msgTypes[33].OneofWrappers = []any{}
 	type x struct{}
 	out := protoimpl.TypeBuilder{
 		File: protoimpl.DescBuilder{

--- a/components/ws-manager-api/go/core_grpc.pb.go
+++ b/components/ws-manager-api/go/core_grpc.pb.go
@@ -307,7 +307,7 @@ func RegisterWorkspaceManagerServer(s grpc.ServiceRegistrar, srv WorkspaceManage
 	s.RegisterService(&WorkspaceManager_ServiceDesc, srv)
 }
 
-func _WorkspaceManager_GetWorkspaces_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+func _WorkspaceManager_GetWorkspaces_Handler(srv any, ctx context.Context, dec func(any) error, interceptor grpc.UnaryServerInterceptor) (any, error) {
 	in := new(GetWorkspacesRequest)
 	if err := dec(in); err != nil {
 		return nil, err
@@ -319,13 +319,13 @@ func _WorkspaceManager_GetWorkspaces_Handler(srv interface{}, ctx context.Contex
 		Server:     srv,
 		FullMethod: "/wsman.WorkspaceManager/GetWorkspaces",
 	}
-	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+	handler := func(ctx context.Context, req any) (any, error) {
 		return srv.(WorkspaceManagerServer).GetWorkspaces(ctx, req.(*GetWorkspacesRequest))
 	}
 	return interceptor(ctx, in, info, handler)
 }
 
-func _WorkspaceManager_StartWorkspace_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+func _WorkspaceManager_StartWorkspace_Handler(srv any, ctx context.Context, dec func(any) error, interceptor grpc.UnaryServerInterceptor) (any, error) {
 	in := new(StartWorkspaceRequest)
 	if err := dec(in); err != nil {
 		return nil, err
@@ -337,13 +337,13 @@ func _WorkspaceManager_StartWorkspace_Handler(srv interface{}, ctx context.Conte
 		Server:     srv,
 		FullMethod: "/wsman.WorkspaceManager/StartWorkspace",
 	}
-	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+	handler := func(ctx context.Context, req any) (any, error) {
 		return srv.(WorkspaceManagerServer).StartWorkspace(ctx, req.(*StartWorkspaceRequest))
 	}
 	return interceptor(ctx, in, info, handler)
 }
 
-func _WorkspaceManager_StopWorkspace_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+func _WorkspaceManager_StopWorkspace_Handler(srv any, ctx context.Context, dec func(any) error, interceptor grpc.UnaryServerInterceptor) (any, error) {
 	in := new(StopWorkspaceRequest)
 	if err := dec(in); err != nil {
 		return nil, err
@@ -355,13 +355,13 @@ func _WorkspaceManager_StopWorkspace_Handler(srv interface{}, ctx context.Contex
 		Server:     srv,
 		FullMethod: "/wsman.WorkspaceManager/StopWorkspace",
 	}
-	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+	handler := func(ctx context.Context, req any) (any, error) {
 		return srv.(WorkspaceManagerServer).StopWorkspace(ctx, req.(*StopWorkspaceRequest))
 	}
 	return interceptor(ctx, in, info, handler)
 }
 
-func _WorkspaceManager_DescribeWorkspace_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+func _WorkspaceManager_DescribeWorkspace_Handler(srv any, ctx context.Context, dec func(any) error, interceptor grpc.UnaryServerInterceptor) (any, error) {
 	in := new(DescribeWorkspaceRequest)
 	if err := dec(in); err != nil {
 		return nil, err
@@ -373,13 +373,13 @@ func _WorkspaceManager_DescribeWorkspace_Handler(srv interface{}, ctx context.Co
 		Server:     srv,
 		FullMethod: "/wsman.WorkspaceManager/DescribeWorkspace",
 	}
-	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+	handler := func(ctx context.Context, req any) (any, error) {
 		return srv.(WorkspaceManagerServer).DescribeWorkspace(ctx, req.(*DescribeWorkspaceRequest))
 	}
 	return interceptor(ctx, in, info, handler)
 }
 
-func _WorkspaceManager_BackupWorkspace_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+func _WorkspaceManager_BackupWorkspace_Handler(srv any, ctx context.Context, dec func(any) error, interceptor grpc.UnaryServerInterceptor) (any, error) {
 	in := new(BackupWorkspaceRequest)
 	if err := dec(in); err != nil {
 		return nil, err
@@ -391,13 +391,13 @@ func _WorkspaceManager_BackupWorkspace_Handler(srv interface{}, ctx context.Cont
 		Server:     srv,
 		FullMethod: "/wsman.WorkspaceManager/BackupWorkspace",
 	}
-	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+	handler := func(ctx context.Context, req any) (any, error) {
 		return srv.(WorkspaceManagerServer).BackupWorkspace(ctx, req.(*BackupWorkspaceRequest))
 	}
 	return interceptor(ctx, in, info, handler)
 }
 
-func _WorkspaceManager_Subscribe_Handler(srv interface{}, stream grpc.ServerStream) error {
+func _WorkspaceManager_Subscribe_Handler(srv any, stream grpc.ServerStream) error {
 	m := new(SubscribeRequest)
 	if err := stream.RecvMsg(m); err != nil {
 		return err
@@ -418,7 +418,7 @@ func (x *workspaceManagerSubscribeServer) Send(m *SubscribeResponse) error {
 	return x.ServerStream.SendMsg(m)
 }
 
-func _WorkspaceManager_MarkActive_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+func _WorkspaceManager_MarkActive_Handler(srv any, ctx context.Context, dec func(any) error, interceptor grpc.UnaryServerInterceptor) (any, error) {
 	in := new(MarkActiveRequest)
 	if err := dec(in); err != nil {
 		return nil, err
@@ -430,13 +430,13 @@ func _WorkspaceManager_MarkActive_Handler(srv interface{}, ctx context.Context, 
 		Server:     srv,
 		FullMethod: "/wsman.WorkspaceManager/MarkActive",
 	}
-	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+	handler := func(ctx context.Context, req any) (any, error) {
 		return srv.(WorkspaceManagerServer).MarkActive(ctx, req.(*MarkActiveRequest))
 	}
 	return interceptor(ctx, in, info, handler)
 }
 
-func _WorkspaceManager_SetTimeout_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+func _WorkspaceManager_SetTimeout_Handler(srv any, ctx context.Context, dec func(any) error, interceptor grpc.UnaryServerInterceptor) (any, error) {
 	in := new(SetTimeoutRequest)
 	if err := dec(in); err != nil {
 		return nil, err
@@ -448,13 +448,13 @@ func _WorkspaceManager_SetTimeout_Handler(srv interface{}, ctx context.Context, 
 		Server:     srv,
 		FullMethod: "/wsman.WorkspaceManager/SetTimeout",
 	}
-	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+	handler := func(ctx context.Context, req any) (any, error) {
 		return srv.(WorkspaceManagerServer).SetTimeout(ctx, req.(*SetTimeoutRequest))
 	}
 	return interceptor(ctx, in, info, handler)
 }
 
-func _WorkspaceManager_ControlPort_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+func _WorkspaceManager_ControlPort_Handler(srv any, ctx context.Context, dec func(any) error, interceptor grpc.UnaryServerInterceptor) (any, error) {
 	in := new(ControlPortRequest)
 	if err := dec(in); err != nil {
 		return nil, err
@@ -466,13 +466,13 @@ func _WorkspaceManager_ControlPort_Handler(srv interface{}, ctx context.Context,
 		Server:     srv,
 		FullMethod: "/wsman.WorkspaceManager/ControlPort",
 	}
-	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+	handler := func(ctx context.Context, req any) (any, error) {
 		return srv.(WorkspaceManagerServer).ControlPort(ctx, req.(*ControlPortRequest))
 	}
 	return interceptor(ctx, in, info, handler)
 }
 
-func _WorkspaceManager_TakeSnapshot_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+func _WorkspaceManager_TakeSnapshot_Handler(srv any, ctx context.Context, dec func(any) error, interceptor grpc.UnaryServerInterceptor) (any, error) {
 	in := new(TakeSnapshotRequest)
 	if err := dec(in); err != nil {
 		return nil, err
@@ -484,13 +484,13 @@ func _WorkspaceManager_TakeSnapshot_Handler(srv interface{}, ctx context.Context
 		Server:     srv,
 		FullMethod: "/wsman.WorkspaceManager/TakeSnapshot",
 	}
-	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+	handler := func(ctx context.Context, req any) (any, error) {
 		return srv.(WorkspaceManagerServer).TakeSnapshot(ctx, req.(*TakeSnapshotRequest))
 	}
 	return interceptor(ctx, in, info, handler)
 }
 
-func _WorkspaceManager_ControlAdmission_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+func _WorkspaceManager_ControlAdmission_Handler(srv any, ctx context.Context, dec func(any) error, interceptor grpc.UnaryServerInterceptor) (any, error) {
 	in := new(ControlAdmissionRequest)
 	if err := dec(in); err != nil {
 		return nil, err
@@ -502,13 +502,13 @@ func _WorkspaceManager_ControlAdmission_Handler(srv interface{}, ctx context.Con
 		Server:     srv,
 		FullMethod: "/wsman.WorkspaceManager/ControlAdmission",
 	}
-	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+	handler := func(ctx context.Context, req any) (any, error) {
 		return srv.(WorkspaceManagerServer).ControlAdmission(ctx, req.(*ControlAdmissionRequest))
 	}
 	return interceptor(ctx, in, info, handler)
 }
 
-func _WorkspaceManager_DeleteVolumeSnapshot_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+func _WorkspaceManager_DeleteVolumeSnapshot_Handler(srv any, ctx context.Context, dec func(any) error, interceptor grpc.UnaryServerInterceptor) (any, error) {
 	in := new(DeleteVolumeSnapshotRequest)
 	if err := dec(in); err != nil {
 		return nil, err
@@ -520,13 +520,13 @@ func _WorkspaceManager_DeleteVolumeSnapshot_Handler(srv interface{}, ctx context
 		Server:     srv,
 		FullMethod: "/wsman.WorkspaceManager/DeleteVolumeSnapshot",
 	}
-	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+	handler := func(ctx context.Context, req any) (any, error) {
 		return srv.(WorkspaceManagerServer).DeleteVolumeSnapshot(ctx, req.(*DeleteVolumeSnapshotRequest))
 	}
 	return interceptor(ctx, in, info, handler)
 }
 
-func _WorkspaceManager_UpdateSSHKey_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+func _WorkspaceManager_UpdateSSHKey_Handler(srv any, ctx context.Context, dec func(any) error, interceptor grpc.UnaryServerInterceptor) (any, error) {
 	in := new(UpdateSSHKeyRequest)
 	if err := dec(in); err != nil {
 		return nil, err
@@ -538,13 +538,13 @@ func _WorkspaceManager_UpdateSSHKey_Handler(srv interface{}, ctx context.Context
 		Server:     srv,
 		FullMethod: "/wsman.WorkspaceManager/UpdateSSHKey",
 	}
-	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+	handler := func(ctx context.Context, req any) (any, error) {
 		return srv.(WorkspaceManagerServer).UpdateSSHKey(ctx, req.(*UpdateSSHKeyRequest))
 	}
 	return interceptor(ctx, in, info, handler)
 }
 
-func _WorkspaceManager_DescribeCluster_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+func _WorkspaceManager_DescribeCluster_Handler(srv any, ctx context.Context, dec func(any) error, interceptor grpc.UnaryServerInterceptor) (any, error) {
 	in := new(DescribeClusterRequest)
 	if err := dec(in); err != nil {
 		return nil, err
@@ -556,7 +556,7 @@ func _WorkspaceManager_DescribeCluster_Handler(srv interface{}, ctx context.Cont
 		Server:     srv,
 		FullMethod: "/wsman.WorkspaceManager/DescribeCluster",
 	}
-	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+	handler := func(ctx context.Context, req any) (any, error) {
 		return srv.(WorkspaceManagerServer).DescribeCluster(ctx, req.(*DescribeClusterRequest))
 	}
 	return interceptor(ctx, in, info, handler)

--- a/components/ws-manager-api/go/mock/mock.go
+++ b/components/ws-manager-api/go/mock/mock.go
@@ -56,7 +56,7 @@ func (mr *MockWorkspaceManager_SubscribeServerMockRecorder) Context() *gomock.Ca
 }
 
 // RecvMsg mocks base method.
-func (m *MockWorkspaceManager_SubscribeServer) RecvMsg(arg0 interface{}) error {
+func (m *MockWorkspaceManager_SubscribeServer) RecvMsg(arg0 any) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "RecvMsg", arg0)
 	ret0, _ := ret[0].(error)
@@ -64,7 +64,7 @@ func (m *MockWorkspaceManager_SubscribeServer) RecvMsg(arg0 interface{}) error {
 }
 
 // RecvMsg indicates an expected call of RecvMsg.
-func (mr *MockWorkspaceManager_SubscribeServerMockRecorder) RecvMsg(arg0 interface{}) *gomock.Call {
+func (mr *MockWorkspaceManager_SubscribeServerMockRecorder) RecvMsg(arg0 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RecvMsg", reflect.TypeOf((*MockWorkspaceManager_SubscribeServer)(nil).RecvMsg), arg0)
 }
@@ -78,7 +78,7 @@ func (m *MockWorkspaceManager_SubscribeServer) Send(arg0 *api.SubscribeResponse)
 }
 
 // Send indicates an expected call of Send.
-func (mr *MockWorkspaceManager_SubscribeServerMockRecorder) Send(arg0 interface{}) *gomock.Call {
+func (mr *MockWorkspaceManager_SubscribeServerMockRecorder) Send(arg0 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Send", reflect.TypeOf((*MockWorkspaceManager_SubscribeServer)(nil).Send), arg0)
 }
@@ -92,13 +92,13 @@ func (m *MockWorkspaceManager_SubscribeServer) SendHeader(arg0 metadata.MD) erro
 }
 
 // SendHeader indicates an expected call of SendHeader.
-func (mr *MockWorkspaceManager_SubscribeServerMockRecorder) SendHeader(arg0 interface{}) *gomock.Call {
+func (mr *MockWorkspaceManager_SubscribeServerMockRecorder) SendHeader(arg0 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SendHeader", reflect.TypeOf((*MockWorkspaceManager_SubscribeServer)(nil).SendHeader), arg0)
 }
 
 // SendMsg mocks base method.
-func (m *MockWorkspaceManager_SubscribeServer) SendMsg(arg0 interface{}) error {
+func (m *MockWorkspaceManager_SubscribeServer) SendMsg(arg0 any) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SendMsg", arg0)
 	ret0, _ := ret[0].(error)
@@ -106,7 +106,7 @@ func (m *MockWorkspaceManager_SubscribeServer) SendMsg(arg0 interface{}) error {
 }
 
 // SendMsg indicates an expected call of SendMsg.
-func (mr *MockWorkspaceManager_SubscribeServerMockRecorder) SendMsg(arg0 interface{}) *gomock.Call {
+func (mr *MockWorkspaceManager_SubscribeServerMockRecorder) SendMsg(arg0 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SendMsg", reflect.TypeOf((*MockWorkspaceManager_SubscribeServer)(nil).SendMsg), arg0)
 }
@@ -120,7 +120,7 @@ func (m *MockWorkspaceManager_SubscribeServer) SetHeader(arg0 metadata.MD) error
 }
 
 // SetHeader indicates an expected call of SetHeader.
-func (mr *MockWorkspaceManager_SubscribeServerMockRecorder) SetHeader(arg0 interface{}) *gomock.Call {
+func (mr *MockWorkspaceManager_SubscribeServerMockRecorder) SetHeader(arg0 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetHeader", reflect.TypeOf((*MockWorkspaceManager_SubscribeServer)(nil).SetHeader), arg0)
 }
@@ -132,7 +132,7 @@ func (m *MockWorkspaceManager_SubscribeServer) SetTrailer(arg0 metadata.MD) {
 }
 
 // SetTrailer indicates an expected call of SetTrailer.
-func (mr *MockWorkspaceManager_SubscribeServerMockRecorder) SetTrailer(arg0 interface{}) *gomock.Call {
+func (mr *MockWorkspaceManager_SubscribeServerMockRecorder) SetTrailer(arg0 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetTrailer", reflect.TypeOf((*MockWorkspaceManager_SubscribeServer)(nil).SetTrailer), arg0)
 }
@@ -170,7 +170,7 @@ func (m *MockWorkspaceManagerServer) BackupWorkspace(arg0 context.Context, arg1 
 }
 
 // BackupWorkspace indicates an expected call of BackupWorkspace.
-func (mr *MockWorkspaceManagerServerMockRecorder) BackupWorkspace(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockWorkspaceManagerServerMockRecorder) BackupWorkspace(arg0, arg1 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BackupWorkspace", reflect.TypeOf((*MockWorkspaceManagerServer)(nil).BackupWorkspace), arg0, arg1)
 }
@@ -185,7 +185,7 @@ func (m *MockWorkspaceManagerServer) ControlAdmission(arg0 context.Context, arg1
 }
 
 // ControlAdmission indicates an expected call of ControlAdmission.
-func (mr *MockWorkspaceManagerServerMockRecorder) ControlAdmission(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockWorkspaceManagerServerMockRecorder) ControlAdmission(arg0, arg1 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ControlAdmission", reflect.TypeOf((*MockWorkspaceManagerServer)(nil).ControlAdmission), arg0, arg1)
 }
@@ -200,7 +200,7 @@ func (m *MockWorkspaceManagerServer) ControlPort(arg0 context.Context, arg1 *api
 }
 
 // ControlPort indicates an expected call of ControlPort.
-func (mr *MockWorkspaceManagerServerMockRecorder) ControlPort(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockWorkspaceManagerServerMockRecorder) ControlPort(arg0, arg1 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ControlPort", reflect.TypeOf((*MockWorkspaceManagerServer)(nil).ControlPort), arg0, arg1)
 }
@@ -215,7 +215,7 @@ func (m *MockWorkspaceManagerServer) DeleteVolumeSnapshot(arg0 context.Context, 
 }
 
 // DeleteVolumeSnapshot indicates an expected call of DeleteVolumeSnapshot.
-func (mr *MockWorkspaceManagerServerMockRecorder) DeleteVolumeSnapshot(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockWorkspaceManagerServerMockRecorder) DeleteVolumeSnapshot(arg0, arg1 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteVolumeSnapshot", reflect.TypeOf((*MockWorkspaceManagerServer)(nil).DeleteVolumeSnapshot), arg0, arg1)
 }
@@ -230,7 +230,7 @@ func (m *MockWorkspaceManagerServer) DescribeCluster(arg0 context.Context, arg1 
 }
 
 // DescribeCluster indicates an expected call of DescribeCluster.
-func (mr *MockWorkspaceManagerServerMockRecorder) DescribeCluster(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockWorkspaceManagerServerMockRecorder) DescribeCluster(arg0, arg1 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeCluster", reflect.TypeOf((*MockWorkspaceManagerServer)(nil).DescribeCluster), arg0, arg1)
 }
@@ -245,7 +245,7 @@ func (m *MockWorkspaceManagerServer) DescribeWorkspace(arg0 context.Context, arg
 }
 
 // DescribeWorkspace indicates an expected call of DescribeWorkspace.
-func (mr *MockWorkspaceManagerServerMockRecorder) DescribeWorkspace(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockWorkspaceManagerServerMockRecorder) DescribeWorkspace(arg0, arg1 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeWorkspace", reflect.TypeOf((*MockWorkspaceManagerServer)(nil).DescribeWorkspace), arg0, arg1)
 }
@@ -260,7 +260,7 @@ func (m *MockWorkspaceManagerServer) GetWorkspaces(arg0 context.Context, arg1 *a
 }
 
 // GetWorkspaces indicates an expected call of GetWorkspaces.
-func (mr *MockWorkspaceManagerServerMockRecorder) GetWorkspaces(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockWorkspaceManagerServerMockRecorder) GetWorkspaces(arg0, arg1 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetWorkspaces", reflect.TypeOf((*MockWorkspaceManagerServer)(nil).GetWorkspaces), arg0, arg1)
 }
@@ -275,7 +275,7 @@ func (m *MockWorkspaceManagerServer) MarkActive(arg0 context.Context, arg1 *api.
 }
 
 // MarkActive indicates an expected call of MarkActive.
-func (mr *MockWorkspaceManagerServerMockRecorder) MarkActive(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockWorkspaceManagerServerMockRecorder) MarkActive(arg0, arg1 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MarkActive", reflect.TypeOf((*MockWorkspaceManagerServer)(nil).MarkActive), arg0, arg1)
 }
@@ -290,7 +290,7 @@ func (m *MockWorkspaceManagerServer) SetTimeout(arg0 context.Context, arg1 *api.
 }
 
 // SetTimeout indicates an expected call of SetTimeout.
-func (mr *MockWorkspaceManagerServerMockRecorder) SetTimeout(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockWorkspaceManagerServerMockRecorder) SetTimeout(arg0, arg1 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetTimeout", reflect.TypeOf((*MockWorkspaceManagerServer)(nil).SetTimeout), arg0, arg1)
 }
@@ -305,7 +305,7 @@ func (m *MockWorkspaceManagerServer) StartWorkspace(arg0 context.Context, arg1 *
 }
 
 // StartWorkspace indicates an expected call of StartWorkspace.
-func (mr *MockWorkspaceManagerServerMockRecorder) StartWorkspace(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockWorkspaceManagerServerMockRecorder) StartWorkspace(arg0, arg1 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StartWorkspace", reflect.TypeOf((*MockWorkspaceManagerServer)(nil).StartWorkspace), arg0, arg1)
 }
@@ -320,7 +320,7 @@ func (m *MockWorkspaceManagerServer) StopWorkspace(arg0 context.Context, arg1 *a
 }
 
 // StopWorkspace indicates an expected call of StopWorkspace.
-func (mr *MockWorkspaceManagerServerMockRecorder) StopWorkspace(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockWorkspaceManagerServerMockRecorder) StopWorkspace(arg0, arg1 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StopWorkspace", reflect.TypeOf((*MockWorkspaceManagerServer)(nil).StopWorkspace), arg0, arg1)
 }
@@ -334,7 +334,7 @@ func (m *MockWorkspaceManagerServer) Subscribe(arg0 *api.SubscribeRequest, arg1 
 }
 
 // Subscribe indicates an expected call of Subscribe.
-func (mr *MockWorkspaceManagerServerMockRecorder) Subscribe(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockWorkspaceManagerServerMockRecorder) Subscribe(arg0, arg1 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Subscribe", reflect.TypeOf((*MockWorkspaceManagerServer)(nil).Subscribe), arg0, arg1)
 }
@@ -349,7 +349,7 @@ func (m *MockWorkspaceManagerServer) TakeSnapshot(arg0 context.Context, arg1 *ap
 }
 
 // TakeSnapshot indicates an expected call of TakeSnapshot.
-func (mr *MockWorkspaceManagerServerMockRecorder) TakeSnapshot(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockWorkspaceManagerServerMockRecorder) TakeSnapshot(arg0, arg1 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TakeSnapshot", reflect.TypeOf((*MockWorkspaceManagerServer)(nil).TakeSnapshot), arg0, arg1)
 }
@@ -364,7 +364,7 @@ func (m *MockWorkspaceManagerServer) UpdateSSHKey(arg0 context.Context, arg1 *ap
 }
 
 // UpdateSSHKey indicates an expected call of UpdateSSHKey.
-func (mr *MockWorkspaceManagerServerMockRecorder) UpdateSSHKey(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockWorkspaceManagerServerMockRecorder) UpdateSSHKey(arg0, arg1 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateSSHKey", reflect.TypeOf((*MockWorkspaceManagerServer)(nil).UpdateSSHKey), arg0, arg1)
 }
@@ -463,7 +463,7 @@ func (mr *MockWorkspaceManager_SubscribeClientMockRecorder) Recv() *gomock.Call 
 }
 
 // RecvMsg mocks base method.
-func (m *MockWorkspaceManager_SubscribeClient) RecvMsg(arg0 interface{}) error {
+func (m *MockWorkspaceManager_SubscribeClient) RecvMsg(arg0 any) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "RecvMsg", arg0)
 	ret0, _ := ret[0].(error)
@@ -471,13 +471,13 @@ func (m *MockWorkspaceManager_SubscribeClient) RecvMsg(arg0 interface{}) error {
 }
 
 // RecvMsg indicates an expected call of RecvMsg.
-func (mr *MockWorkspaceManager_SubscribeClientMockRecorder) RecvMsg(arg0 interface{}) *gomock.Call {
+func (mr *MockWorkspaceManager_SubscribeClientMockRecorder) RecvMsg(arg0 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RecvMsg", reflect.TypeOf((*MockWorkspaceManager_SubscribeClient)(nil).RecvMsg), arg0)
 }
 
 // SendMsg mocks base method.
-func (m *MockWorkspaceManager_SubscribeClient) SendMsg(arg0 interface{}) error {
+func (m *MockWorkspaceManager_SubscribeClient) SendMsg(arg0 any) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SendMsg", arg0)
 	ret0, _ := ret[0].(error)
@@ -485,7 +485,7 @@ func (m *MockWorkspaceManager_SubscribeClient) SendMsg(arg0 interface{}) error {
 }
 
 // SendMsg indicates an expected call of SendMsg.
-func (mr *MockWorkspaceManager_SubscribeClientMockRecorder) SendMsg(arg0 interface{}) *gomock.Call {
+func (mr *MockWorkspaceManager_SubscribeClientMockRecorder) SendMsg(arg0 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SendMsg", reflect.TypeOf((*MockWorkspaceManager_SubscribeClient)(nil).SendMsg), arg0)
 }
@@ -530,7 +530,7 @@ func (m *MockWorkspaceManagerClient) EXPECT() *MockWorkspaceManagerClientMockRec
 // BackupWorkspace mocks base method.
 func (m *MockWorkspaceManagerClient) BackupWorkspace(arg0 context.Context, arg1 *api.BackupWorkspaceRequest, arg2 ...grpc.CallOption) (*api.BackupWorkspaceResponse, error) {
 	m.ctrl.T.Helper()
-	varargs := []interface{}{arg0, arg1}
+	varargs := []any{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
 	}
@@ -541,16 +541,16 @@ func (m *MockWorkspaceManagerClient) BackupWorkspace(arg0 context.Context, arg1 
 }
 
 // BackupWorkspace indicates an expected call of BackupWorkspace.
-func (mr *MockWorkspaceManagerClientMockRecorder) BackupWorkspace(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+func (mr *MockWorkspaceManagerClientMockRecorder) BackupWorkspace(arg0, arg1 any, arg2 ...any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	varargs := append([]interface{}{arg0, arg1}, arg2...)
+	varargs := append([]any{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BackupWorkspace", reflect.TypeOf((*MockWorkspaceManagerClient)(nil).BackupWorkspace), varargs...)
 }
 
 // ControlAdmission mocks base method.
 func (m *MockWorkspaceManagerClient) ControlAdmission(arg0 context.Context, arg1 *api.ControlAdmissionRequest, arg2 ...grpc.CallOption) (*api.ControlAdmissionResponse, error) {
 	m.ctrl.T.Helper()
-	varargs := []interface{}{arg0, arg1}
+	varargs := []any{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
 	}
@@ -561,16 +561,16 @@ func (m *MockWorkspaceManagerClient) ControlAdmission(arg0 context.Context, arg1
 }
 
 // ControlAdmission indicates an expected call of ControlAdmission.
-func (mr *MockWorkspaceManagerClientMockRecorder) ControlAdmission(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+func (mr *MockWorkspaceManagerClientMockRecorder) ControlAdmission(arg0, arg1 any, arg2 ...any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	varargs := append([]interface{}{arg0, arg1}, arg2...)
+	varargs := append([]any{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ControlAdmission", reflect.TypeOf((*MockWorkspaceManagerClient)(nil).ControlAdmission), varargs...)
 }
 
 // ControlPort mocks base method.
 func (m *MockWorkspaceManagerClient) ControlPort(arg0 context.Context, arg1 *api.ControlPortRequest, arg2 ...grpc.CallOption) (*api.ControlPortResponse, error) {
 	m.ctrl.T.Helper()
-	varargs := []interface{}{arg0, arg1}
+	varargs := []any{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
 	}
@@ -581,16 +581,16 @@ func (m *MockWorkspaceManagerClient) ControlPort(arg0 context.Context, arg1 *api
 }
 
 // ControlPort indicates an expected call of ControlPort.
-func (mr *MockWorkspaceManagerClientMockRecorder) ControlPort(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+func (mr *MockWorkspaceManagerClientMockRecorder) ControlPort(arg0, arg1 any, arg2 ...any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	varargs := append([]interface{}{arg0, arg1}, arg2...)
+	varargs := append([]any{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ControlPort", reflect.TypeOf((*MockWorkspaceManagerClient)(nil).ControlPort), varargs...)
 }
 
 // DeleteVolumeSnapshot mocks base method.
 func (m *MockWorkspaceManagerClient) DeleteVolumeSnapshot(arg0 context.Context, arg1 *api.DeleteVolumeSnapshotRequest, arg2 ...grpc.CallOption) (*api.DeleteVolumeSnapshotResponse, error) {
 	m.ctrl.T.Helper()
-	varargs := []interface{}{arg0, arg1}
+	varargs := []any{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
 	}
@@ -601,16 +601,16 @@ func (m *MockWorkspaceManagerClient) DeleteVolumeSnapshot(arg0 context.Context, 
 }
 
 // DeleteVolumeSnapshot indicates an expected call of DeleteVolumeSnapshot.
-func (mr *MockWorkspaceManagerClientMockRecorder) DeleteVolumeSnapshot(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+func (mr *MockWorkspaceManagerClientMockRecorder) DeleteVolumeSnapshot(arg0, arg1 any, arg2 ...any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	varargs := append([]interface{}{arg0, arg1}, arg2...)
+	varargs := append([]any{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteVolumeSnapshot", reflect.TypeOf((*MockWorkspaceManagerClient)(nil).DeleteVolumeSnapshot), varargs...)
 }
 
 // DescribeCluster mocks base method.
 func (m *MockWorkspaceManagerClient) DescribeCluster(arg0 context.Context, arg1 *api.DescribeClusterRequest, arg2 ...grpc.CallOption) (*api.DescribeClusterResponse, error) {
 	m.ctrl.T.Helper()
-	varargs := []interface{}{arg0, arg1}
+	varargs := []any{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
 	}
@@ -621,16 +621,16 @@ func (m *MockWorkspaceManagerClient) DescribeCluster(arg0 context.Context, arg1 
 }
 
 // DescribeCluster indicates an expected call of DescribeCluster.
-func (mr *MockWorkspaceManagerClientMockRecorder) DescribeCluster(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+func (mr *MockWorkspaceManagerClientMockRecorder) DescribeCluster(arg0, arg1 any, arg2 ...any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	varargs := append([]interface{}{arg0, arg1}, arg2...)
+	varargs := append([]any{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeCluster", reflect.TypeOf((*MockWorkspaceManagerClient)(nil).DescribeCluster), varargs...)
 }
 
 // DescribeWorkspace mocks base method.
 func (m *MockWorkspaceManagerClient) DescribeWorkspace(arg0 context.Context, arg1 *api.DescribeWorkspaceRequest, arg2 ...grpc.CallOption) (*api.DescribeWorkspaceResponse, error) {
 	m.ctrl.T.Helper()
-	varargs := []interface{}{arg0, arg1}
+	varargs := []any{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
 	}
@@ -641,16 +641,16 @@ func (m *MockWorkspaceManagerClient) DescribeWorkspace(arg0 context.Context, arg
 }
 
 // DescribeWorkspace indicates an expected call of DescribeWorkspace.
-func (mr *MockWorkspaceManagerClientMockRecorder) DescribeWorkspace(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+func (mr *MockWorkspaceManagerClientMockRecorder) DescribeWorkspace(arg0, arg1 any, arg2 ...any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	varargs := append([]interface{}{arg0, arg1}, arg2...)
+	varargs := append([]any{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeWorkspace", reflect.TypeOf((*MockWorkspaceManagerClient)(nil).DescribeWorkspace), varargs...)
 }
 
 // GetWorkspaces mocks base method.
 func (m *MockWorkspaceManagerClient) GetWorkspaces(arg0 context.Context, arg1 *api.GetWorkspacesRequest, arg2 ...grpc.CallOption) (*api.GetWorkspacesResponse, error) {
 	m.ctrl.T.Helper()
-	varargs := []interface{}{arg0, arg1}
+	varargs := []any{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
 	}
@@ -661,16 +661,16 @@ func (m *MockWorkspaceManagerClient) GetWorkspaces(arg0 context.Context, arg1 *a
 }
 
 // GetWorkspaces indicates an expected call of GetWorkspaces.
-func (mr *MockWorkspaceManagerClientMockRecorder) GetWorkspaces(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+func (mr *MockWorkspaceManagerClientMockRecorder) GetWorkspaces(arg0, arg1 any, arg2 ...any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	varargs := append([]interface{}{arg0, arg1}, arg2...)
+	varargs := append([]any{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetWorkspaces", reflect.TypeOf((*MockWorkspaceManagerClient)(nil).GetWorkspaces), varargs...)
 }
 
 // MarkActive mocks base method.
 func (m *MockWorkspaceManagerClient) MarkActive(arg0 context.Context, arg1 *api.MarkActiveRequest, arg2 ...grpc.CallOption) (*api.MarkActiveResponse, error) {
 	m.ctrl.T.Helper()
-	varargs := []interface{}{arg0, arg1}
+	varargs := []any{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
 	}
@@ -681,16 +681,16 @@ func (m *MockWorkspaceManagerClient) MarkActive(arg0 context.Context, arg1 *api.
 }
 
 // MarkActive indicates an expected call of MarkActive.
-func (mr *MockWorkspaceManagerClientMockRecorder) MarkActive(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+func (mr *MockWorkspaceManagerClientMockRecorder) MarkActive(arg0, arg1 any, arg2 ...any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	varargs := append([]interface{}{arg0, arg1}, arg2...)
+	varargs := append([]any{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MarkActive", reflect.TypeOf((*MockWorkspaceManagerClient)(nil).MarkActive), varargs...)
 }
 
 // SetTimeout mocks base method.
 func (m *MockWorkspaceManagerClient) SetTimeout(arg0 context.Context, arg1 *api.SetTimeoutRequest, arg2 ...grpc.CallOption) (*api.SetTimeoutResponse, error) {
 	m.ctrl.T.Helper()
-	varargs := []interface{}{arg0, arg1}
+	varargs := []any{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
 	}
@@ -701,16 +701,16 @@ func (m *MockWorkspaceManagerClient) SetTimeout(arg0 context.Context, arg1 *api.
 }
 
 // SetTimeout indicates an expected call of SetTimeout.
-func (mr *MockWorkspaceManagerClientMockRecorder) SetTimeout(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+func (mr *MockWorkspaceManagerClientMockRecorder) SetTimeout(arg0, arg1 any, arg2 ...any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	varargs := append([]interface{}{arg0, arg1}, arg2...)
+	varargs := append([]any{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetTimeout", reflect.TypeOf((*MockWorkspaceManagerClient)(nil).SetTimeout), varargs...)
 }
 
 // StartWorkspace mocks base method.
 func (m *MockWorkspaceManagerClient) StartWorkspace(arg0 context.Context, arg1 *api.StartWorkspaceRequest, arg2 ...grpc.CallOption) (*api.StartWorkspaceResponse, error) {
 	m.ctrl.T.Helper()
-	varargs := []interface{}{arg0, arg1}
+	varargs := []any{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
 	}
@@ -721,16 +721,16 @@ func (m *MockWorkspaceManagerClient) StartWorkspace(arg0 context.Context, arg1 *
 }
 
 // StartWorkspace indicates an expected call of StartWorkspace.
-func (mr *MockWorkspaceManagerClientMockRecorder) StartWorkspace(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+func (mr *MockWorkspaceManagerClientMockRecorder) StartWorkspace(arg0, arg1 any, arg2 ...any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	varargs := append([]interface{}{arg0, arg1}, arg2...)
+	varargs := append([]any{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StartWorkspace", reflect.TypeOf((*MockWorkspaceManagerClient)(nil).StartWorkspace), varargs...)
 }
 
 // StopWorkspace mocks base method.
 func (m *MockWorkspaceManagerClient) StopWorkspace(arg0 context.Context, arg1 *api.StopWorkspaceRequest, arg2 ...grpc.CallOption) (*api.StopWorkspaceResponse, error) {
 	m.ctrl.T.Helper()
-	varargs := []interface{}{arg0, arg1}
+	varargs := []any{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
 	}
@@ -741,16 +741,16 @@ func (m *MockWorkspaceManagerClient) StopWorkspace(arg0 context.Context, arg1 *a
 }
 
 // StopWorkspace indicates an expected call of StopWorkspace.
-func (mr *MockWorkspaceManagerClientMockRecorder) StopWorkspace(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+func (mr *MockWorkspaceManagerClientMockRecorder) StopWorkspace(arg0, arg1 any, arg2 ...any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	varargs := append([]interface{}{arg0, arg1}, arg2...)
+	varargs := append([]any{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StopWorkspace", reflect.TypeOf((*MockWorkspaceManagerClient)(nil).StopWorkspace), varargs...)
 }
 
 // Subscribe mocks base method.
 func (m *MockWorkspaceManagerClient) Subscribe(arg0 context.Context, arg1 *api.SubscribeRequest, arg2 ...grpc.CallOption) (api.WorkspaceManager_SubscribeClient, error) {
 	m.ctrl.T.Helper()
-	varargs := []interface{}{arg0, arg1}
+	varargs := []any{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
 	}
@@ -761,16 +761,16 @@ func (m *MockWorkspaceManagerClient) Subscribe(arg0 context.Context, arg1 *api.S
 }
 
 // Subscribe indicates an expected call of Subscribe.
-func (mr *MockWorkspaceManagerClientMockRecorder) Subscribe(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+func (mr *MockWorkspaceManagerClientMockRecorder) Subscribe(arg0, arg1 any, arg2 ...any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	varargs := append([]interface{}{arg0, arg1}, arg2...)
+	varargs := append([]any{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Subscribe", reflect.TypeOf((*MockWorkspaceManagerClient)(nil).Subscribe), varargs...)
 }
 
 // TakeSnapshot mocks base method.
 func (m *MockWorkspaceManagerClient) TakeSnapshot(arg0 context.Context, arg1 *api.TakeSnapshotRequest, arg2 ...grpc.CallOption) (*api.TakeSnapshotResponse, error) {
 	m.ctrl.T.Helper()
-	varargs := []interface{}{arg0, arg1}
+	varargs := []any{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
 	}
@@ -781,16 +781,16 @@ func (m *MockWorkspaceManagerClient) TakeSnapshot(arg0 context.Context, arg1 *ap
 }
 
 // TakeSnapshot indicates an expected call of TakeSnapshot.
-func (mr *MockWorkspaceManagerClientMockRecorder) TakeSnapshot(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+func (mr *MockWorkspaceManagerClientMockRecorder) TakeSnapshot(arg0, arg1 any, arg2 ...any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	varargs := append([]interface{}{arg0, arg1}, arg2...)
+	varargs := append([]any{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TakeSnapshot", reflect.TypeOf((*MockWorkspaceManagerClient)(nil).TakeSnapshot), varargs...)
 }
 
 // UpdateSSHKey mocks base method.
 func (m *MockWorkspaceManagerClient) UpdateSSHKey(arg0 context.Context, arg1 *api.UpdateSSHKeyRequest, arg2 ...grpc.CallOption) (*api.UpdateSSHKeyResponse, error) {
 	m.ctrl.T.Helper()
-	varargs := []interface{}{arg0, arg1}
+	varargs := []any{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
 	}
@@ -801,8 +801,8 @@ func (m *MockWorkspaceManagerClient) UpdateSSHKey(arg0 context.Context, arg1 *ap
 }
 
 // UpdateSSHKey indicates an expected call of UpdateSSHKey.
-func (mr *MockWorkspaceManagerClientMockRecorder) UpdateSSHKey(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+func (mr *MockWorkspaceManagerClientMockRecorder) UpdateSSHKey(arg0, arg1 any, arg2 ...any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	varargs := append([]interface{}{arg0, arg1}, arg2...)
+	varargs := append([]any{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateSSHKey", reflect.TypeOf((*MockWorkspaceManagerClient)(nil).UpdateSSHKey), varargs...)
 }

--- a/components/ws-manager-bridge-api/go/cluster-service.pb.go
+++ b/components/ws-manager-bridge-api/go/cluster-service.pb.go
@@ -1226,7 +1226,7 @@ func file_cluster_service_proto_rawDescGZIP() []byte {
 
 var file_cluster_service_proto_enumTypes = make([]protoimpl.EnumInfo, 2)
 var file_cluster_service_proto_msgTypes = make([]protoimpl.MessageInfo, 15)
-var file_cluster_service_proto_goTypes = []interface{}{
+var file_cluster_service_proto_goTypes = []any{
 	(Preferability)(0),                         // 0: workspacemanagerbridge.Preferability
 	(ClusterState)(0),                          // 1: workspacemanagerbridge.ClusterState
 	(*RegisterRequest)(nil),                    // 2: workspacemanagerbridge.RegisterRequest
@@ -1278,7 +1278,7 @@ func file_cluster_service_proto_init() {
 		return
 	}
 	if !protoimpl.UnsafeEnabled {
-		file_cluster_service_proto_msgTypes[0].Exporter = func(v interface{}, i int) interface{} {
+		file_cluster_service_proto_msgTypes[0].Exporter = func(v any, i int) any {
 			switch v := v.(*RegisterRequest); i {
 			case 0:
 				return &v.state
@@ -1290,7 +1290,7 @@ func file_cluster_service_proto_init() {
 				return nil
 			}
 		}
-		file_cluster_service_proto_msgTypes[1].Exporter = func(v interface{}, i int) interface{} {
+		file_cluster_service_proto_msgTypes[1].Exporter = func(v any, i int) any {
 			switch v := v.(*RegisterResponse); i {
 			case 0:
 				return &v.state
@@ -1302,7 +1302,7 @@ func file_cluster_service_proto_init() {
 				return nil
 			}
 		}
-		file_cluster_service_proto_msgTypes[2].Exporter = func(v interface{}, i int) interface{} {
+		file_cluster_service_proto_msgTypes[2].Exporter = func(v any, i int) any {
 			switch v := v.(*TlsConfig); i {
 			case 0:
 				return &v.state
@@ -1314,7 +1314,7 @@ func file_cluster_service_proto_init() {
 				return nil
 			}
 		}
-		file_cluster_service_proto_msgTypes[3].Exporter = func(v interface{}, i int) interface{} {
+		file_cluster_service_proto_msgTypes[3].Exporter = func(v any, i int) any {
 			switch v := v.(*RegistrationHints); i {
 			case 0:
 				return &v.state
@@ -1326,7 +1326,7 @@ func file_cluster_service_proto_init() {
 				return nil
 			}
 		}
-		file_cluster_service_proto_msgTypes[4].Exporter = func(v interface{}, i int) interface{} {
+		file_cluster_service_proto_msgTypes[4].Exporter = func(v any, i int) any {
 			switch v := v.(*AdmissionConstraint); i {
 			case 0:
 				return &v.state
@@ -1338,7 +1338,7 @@ func file_cluster_service_proto_init() {
 				return nil
 			}
 		}
-		file_cluster_service_proto_msgTypes[5].Exporter = func(v interface{}, i int) interface{} {
+		file_cluster_service_proto_msgTypes[5].Exporter = func(v any, i int) any {
 			switch v := v.(*ClusterStatus); i {
 			case 0:
 				return &v.state
@@ -1350,7 +1350,7 @@ func file_cluster_service_proto_init() {
 				return nil
 			}
 		}
-		file_cluster_service_proto_msgTypes[6].Exporter = func(v interface{}, i int) interface{} {
+		file_cluster_service_proto_msgTypes[6].Exporter = func(v any, i int) any {
 			switch v := v.(*UpdateRequest); i {
 			case 0:
 				return &v.state
@@ -1362,7 +1362,7 @@ func file_cluster_service_proto_init() {
 				return nil
 			}
 		}
-		file_cluster_service_proto_msgTypes[7].Exporter = func(v interface{}, i int) interface{} {
+		file_cluster_service_proto_msgTypes[7].Exporter = func(v any, i int) any {
 			switch v := v.(*ModifyAdmissionConstraint); i {
 			case 0:
 				return &v.state
@@ -1374,7 +1374,7 @@ func file_cluster_service_proto_init() {
 				return nil
 			}
 		}
-		file_cluster_service_proto_msgTypes[8].Exporter = func(v interface{}, i int) interface{} {
+		file_cluster_service_proto_msgTypes[8].Exporter = func(v any, i int) any {
 			switch v := v.(*UpdateResponse); i {
 			case 0:
 				return &v.state
@@ -1386,7 +1386,7 @@ func file_cluster_service_proto_init() {
 				return nil
 			}
 		}
-		file_cluster_service_proto_msgTypes[9].Exporter = func(v interface{}, i int) interface{} {
+		file_cluster_service_proto_msgTypes[9].Exporter = func(v any, i int) any {
 			switch v := v.(*DeregisterRequest); i {
 			case 0:
 				return &v.state
@@ -1398,7 +1398,7 @@ func file_cluster_service_proto_init() {
 				return nil
 			}
 		}
-		file_cluster_service_proto_msgTypes[10].Exporter = func(v interface{}, i int) interface{} {
+		file_cluster_service_proto_msgTypes[10].Exporter = func(v any, i int) any {
 			switch v := v.(*DeregisterResponse); i {
 			case 0:
 				return &v.state
@@ -1410,7 +1410,7 @@ func file_cluster_service_proto_init() {
 				return nil
 			}
 		}
-		file_cluster_service_proto_msgTypes[11].Exporter = func(v interface{}, i int) interface{} {
+		file_cluster_service_proto_msgTypes[11].Exporter = func(v any, i int) any {
 			switch v := v.(*ListRequest); i {
 			case 0:
 				return &v.state
@@ -1422,7 +1422,7 @@ func file_cluster_service_proto_init() {
 				return nil
 			}
 		}
-		file_cluster_service_proto_msgTypes[12].Exporter = func(v interface{}, i int) interface{} {
+		file_cluster_service_proto_msgTypes[12].Exporter = func(v any, i int) any {
 			switch v := v.(*ListResponse); i {
 			case 0:
 				return &v.state
@@ -1434,7 +1434,7 @@ func file_cluster_service_proto_init() {
 				return nil
 			}
 		}
-		file_cluster_service_proto_msgTypes[13].Exporter = func(v interface{}, i int) interface{} {
+		file_cluster_service_proto_msgTypes[13].Exporter = func(v any, i int) any {
 			switch v := v.(*AdmissionConstraint_FeaturePreview); i {
 			case 0:
 				return &v.state
@@ -1446,7 +1446,7 @@ func file_cluster_service_proto_init() {
 				return nil
 			}
 		}
-		file_cluster_service_proto_msgTypes[14].Exporter = func(v interface{}, i int) interface{} {
+		file_cluster_service_proto_msgTypes[14].Exporter = func(v any, i int) any {
 			switch v := v.(*AdmissionConstraint_HasPermission); i {
 			case 0:
 				return &v.state
@@ -1459,13 +1459,13 @@ func file_cluster_service_proto_init() {
 			}
 		}
 	}
-	file_cluster_service_proto_msgTypes[4].OneofWrappers = []interface{}{
+	file_cluster_service_proto_msgTypes[4].OneofWrappers = []any{
 		(*AdmissionConstraint_HasFeaturePreview)(nil),
 		(*AdmissionConstraint_HasPermission_)(nil),
 		(*AdmissionConstraint_HasUserLevel)(nil),
 		(*AdmissionConstraint_HasMoreResources)(nil),
 	}
-	file_cluster_service_proto_msgTypes[6].OneofWrappers = []interface{}{
+	file_cluster_service_proto_msgTypes[6].OneofWrappers = []any{
 		(*UpdateRequest_Score)(nil),
 		(*UpdateRequest_MaxScore)(nil),
 		(*UpdateRequest_Cordoned)(nil),

--- a/components/ws-manager-bridge-api/go/cluster-service_grpc.pb.go
+++ b/components/ws-manager-bridge-api/go/cluster-service_grpc.pb.go
@@ -124,7 +124,7 @@ func RegisterClusterServiceServer(s grpc.ServiceRegistrar, srv ClusterServiceSer
 	s.RegisterService(&ClusterService_ServiceDesc, srv)
 }
 
-func _ClusterService_Register_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+func _ClusterService_Register_Handler(srv any, ctx context.Context, dec func(any) error, interceptor grpc.UnaryServerInterceptor) (any, error) {
 	in := new(RegisterRequest)
 	if err := dec(in); err != nil {
 		return nil, err
@@ -136,13 +136,13 @@ func _ClusterService_Register_Handler(srv interface{}, ctx context.Context, dec 
 		Server:     srv,
 		FullMethod: "/workspacemanagerbridge.ClusterService/Register",
 	}
-	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+	handler := func(ctx context.Context, req any) (any, error) {
 		return srv.(ClusterServiceServer).Register(ctx, req.(*RegisterRequest))
 	}
 	return interceptor(ctx, in, info, handler)
 }
 
-func _ClusterService_Update_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+func _ClusterService_Update_Handler(srv any, ctx context.Context, dec func(any) error, interceptor grpc.UnaryServerInterceptor) (any, error) {
 	in := new(UpdateRequest)
 	if err := dec(in); err != nil {
 		return nil, err
@@ -154,13 +154,13 @@ func _ClusterService_Update_Handler(srv interface{}, ctx context.Context, dec fu
 		Server:     srv,
 		FullMethod: "/workspacemanagerbridge.ClusterService/Update",
 	}
-	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+	handler := func(ctx context.Context, req any) (any, error) {
 		return srv.(ClusterServiceServer).Update(ctx, req.(*UpdateRequest))
 	}
 	return interceptor(ctx, in, info, handler)
 }
 
-func _ClusterService_Deregister_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+func _ClusterService_Deregister_Handler(srv any, ctx context.Context, dec func(any) error, interceptor grpc.UnaryServerInterceptor) (any, error) {
 	in := new(DeregisterRequest)
 	if err := dec(in); err != nil {
 		return nil, err
@@ -172,13 +172,13 @@ func _ClusterService_Deregister_Handler(srv interface{}, ctx context.Context, de
 		Server:     srv,
 		FullMethod: "/workspacemanagerbridge.ClusterService/Deregister",
 	}
-	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+	handler := func(ctx context.Context, req any) (any, error) {
 		return srv.(ClusterServiceServer).Deregister(ctx, req.(*DeregisterRequest))
 	}
 	return interceptor(ctx, in, info, handler)
 }
 
-func _ClusterService_List_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+func _ClusterService_List_Handler(srv any, ctx context.Context, dec func(any) error, interceptor grpc.UnaryServerInterceptor) (any, error) {
 	in := new(ListRequest)
 	if err := dec(in); err != nil {
 		return nil, err
@@ -190,7 +190,7 @@ func _ClusterService_List_Handler(srv interface{}, ctx context.Context, dec func
 		Server:     srv,
 		FullMethod: "/workspacemanagerbridge.ClusterService/List",
 	}
-	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+	handler := func(ctx context.Context, req any) (any, error) {
 		return srv.(ClusterServiceServer).List(ctx, req.(*ListRequest))
 	}
 	return interceptor(ctx, in, info, handler)

--- a/components/ws-manager/cmd/generate-wsspec.go
+++ b/components/ws-manager/cmd/generate-wsspec.go
@@ -26,7 +26,7 @@ var generateWsspecCmd = &cobra.Command{
 		schema.Title = "ws-manager wsspec schema - generated using wsman generate wsspec"
 		schema.Ref = "#/definitions/StartWorkspaceSpec"
 
-		initializers := map[string]interface{}{
+		initializers := map[string]any{
 			"WorkspaceInitializer_Empty":    &csapi.WorkspaceInitializer_Empty{},
 			"WorkspaceInitializer_Git":      &csapi.WorkspaceInitializer_Git{},
 			"WorkspaceInitializer_Snapshot": &csapi.WorkspaceInitializer_Snapshot{},

--- a/components/ws-manager/pkg/clock/clock_test.go
+++ b/components/ws-manager/pkg/clock/clock_test.go
@@ -13,7 +13,7 @@ import (
 func TestTick(t *testing.T) {
 	type Expectation struct {
 		Samples                []uint64
-		Panic                  interface{}
+		Panic                  any
 		MonotonicityViolations int
 	}
 

--- a/components/ws-manager/pkg/manager/create_test.go
+++ b/components/ws-manager/pkg/manager/create_test.go
@@ -38,7 +38,7 @@ func TestCreateDefiniteWorkspacePod(t *testing.T) {
 	}
 	type tpl struct {
 		FN      string
-		Content interface{}
+		Content any
 		Setter  func(fn string)
 	}
 	toTpl := func(path string, cls WorkspaceClass, c *config.WorkspacePodTemplateConfiguration) []tpl {
@@ -70,7 +70,7 @@ func TestCreateDefiniteWorkspacePod(t *testing.T) {
 	test := ctesting.FixtureTest{
 		T:    t,
 		Path: "testdata/cdwp_*.json",
-		Test: func(t *testing.T, input interface{}) interface{} {
+		Test: func(t *testing.T, input any) any {
 			fixture := input.(*fixture)
 
 			mgmtCfg := forTestingOnlyManagerConfig()
@@ -182,8 +182,8 @@ func TestCreateDefiniteWorkspacePod(t *testing.T) {
 
 			return &result
 		},
-		Fixture: func() interface{} { return &fixture{} },
-		Gold:    func() interface{} { return &gold{} },
+		Fixture: func() any { return &fixture{} },
+		Gold:    func() any { return &gold{} },
 	}
 	test.Run()
 }
@@ -213,7 +213,7 @@ func TestCreatePVCForWorkspacePod(t *testing.T) {
 	test := ctesting.FixtureTest{
 		T:    t,
 		Path: "testdata/cpwp_*.json",
-		Test: func(t *testing.T, input interface{}) interface{} {
+		Test: func(t *testing.T, input any) any {
 			fixture := input.(*fixture)
 
 			mgmtCfg := forTestingOnlyManagerConfig()
@@ -299,8 +299,8 @@ func TestCreatePVCForWorkspacePod(t *testing.T) {
 
 			return &result
 		},
-		Fixture: func() interface{} { return &fixture{} },
-		Gold:    func() interface{} { return &gold{} },
+		Fixture: func() any { return &fixture{} },
+		Gold:    func() any { return &gold{} },
 	}
 	test.Run()
 }

--- a/components/ws-manager/pkg/manager/integration_test.go
+++ b/components/ws-manager/pkg/manager/integration_test.go
@@ -322,7 +322,7 @@ func (test *SingleWorkspaceIntegrationTest) Run(t *testing.T) {
 	}
 	files := []struct {
 		tplfn  string
-		ctnt   interface{}
+		ctnt   any
 		setter func(fn string)
 	}{
 		{"default-template.yaml", test.PodTemplates.Default, func(fn string) {

--- a/components/ws-manager/pkg/manager/manager.go
+++ b/components/ws-manager/pkg/manager/manager.go
@@ -588,7 +588,7 @@ func validateStartWorkspaceRequest(req *api.StartWorkspaceRequest) error {
 	return nil
 }
 
-func isValidWorkspaceType(value interface{}) error {
+func isValidWorkspaceType(value any) error {
 	s, ok := value.(api.WorkspaceType)
 	if !ok {
 		return xerrors.Errorf("value is not a workspace type")
@@ -602,7 +602,7 @@ func isValidWorkspaceType(value interface{}) error {
 	return nil
 }
 
-func areValidPorts(value interface{}) error {
+func areValidPorts(value any) error {
 	s, ok := value.([]*api.PortSpec)
 	if !ok {
 		return xerrors.Errorf("value is not a port spec list")
@@ -707,7 +707,7 @@ func deleteWorkspacePodForce(clientset client.Client, name, namespace string) er
 
 	return nil
 }
-func areValidFeatureFlags(value interface{}) error {
+func areValidFeatureFlags(value any) error {
 	s, ok := value.([]api.WorkspaceFeatureFlag)
 	if !ok {
 		return xerrors.Errorf("value not a feature flag list")

--- a/components/ws-manager/pkg/manager/manager_test.go
+++ b/components/ws-manager/pkg/manager/manager_test.go
@@ -33,9 +33,9 @@ func TestValidateStartWorkspaceRequest(t *testing.T) {
 	test := ctesting.FixtureTest{
 		T:       t,
 		Path:    "testdata/validateStartReq_*.json",
-		Fixture: func() interface{} { return &fixture{} },
-		Gold:    func() interface{} { return &gold{} },
-		Test: func(t *testing.T, input interface{}) interface{} {
+		Fixture: func() any { return &fixture{} },
+		Gold:    func() any { return &gold{} },
+		Test: func(t *testing.T, input any) any {
 			fixture := input.(*fixture)
 			if fixture.Req == nil {
 				t.Errorf("request is nil")
@@ -74,7 +74,7 @@ func TestControlPort(t *testing.T) {
 	test := ctesting.FixtureTest{
 		T:    t,
 		Path: "testdata/controlPort_*.json",
-		Test: func(t *testing.T, input interface{}) interface{} {
+		Test: func(t *testing.T, input any) any {
 			fixture := input.(*fixture)
 
 			manager := forTestingOnlyGetManager(t)
@@ -118,8 +118,8 @@ func TestControlPort(t *testing.T) {
 
 			return &result
 		},
-		Fixture: func() interface{} { return &fixture{} },
-		Gold:    func() interface{} { return &gold{} },
+		Fixture: func() any { return &fixture{} },
+		Gold:    func() any { return &gold{} },
 	}
 	test.Run()
 }
@@ -138,7 +138,7 @@ func TestGetWorkspaces(t *testing.T) {
 	test := ctesting.FixtureTest{
 		T:    t,
 		Path: "testdata/getWorkspaces_*.json",
-		Test: func(t *testing.T, input interface{}) interface{} {
+		Test: func(t *testing.T, input any) any {
 			fixture := input.(*fixture)
 
 			manager := forTestingOnlyGetManager(t)
@@ -181,8 +181,8 @@ func TestGetWorkspaces(t *testing.T) {
 
 			return &result
 		},
-		Fixture: func() interface{} { return &fixture{} },
-		Gold:    func() interface{} { return &gold{} },
+		Fixture: func() any { return &fixture{} },
+		Gold:    func() any { return &gold{} },
 	}
 	test.Run()
 }

--- a/components/ws-manager/pkg/manager/monitor_integration_test.go
+++ b/components/ws-manager/pkg/manager/monitor_integration_test.go
@@ -56,9 +56,9 @@ func TestIntegrationWorkspaceDisposal(t *testing.T) {
 					r.Spec.WorkspaceImage = "does-not-exist"
 				},
 				MockWsdaemon: func(t *testing.T, s *wsdaemon_mock.MockWorkspaceContentServiceServer) {
-					s.EXPECT().InitWorkspace(gomock.Any(), gomock.Any()).DoAndReturn(func(a, b interface{}) { time.Sleep(1 * time.Second) }).Return(&wsdaemon.InitWorkspaceResponse{}, nil)
+					s.EXPECT().InitWorkspace(gomock.Any(), gomock.Any()).DoAndReturn(func(a, b any) { time.Sleep(1 * time.Second) }).Return(&wsdaemon.InitWorkspaceResponse{}, nil)
 					s.EXPECT().WaitForInit(gomock.Any(), gomock.Any()).Return(&wsdaemon.WaitForInitResponse{}, nil).AnyTimes()
-					s.EXPECT().DisposeWorkspace(gomock.Any(), matches(func(a interface{}) bool {
+					s.EXPECT().DisposeWorkspace(gomock.Any(), matches(func(a any) bool {
 						req, ok := a.(*wsdaemon.DisposeWorkspaceRequest)
 						if !ok {
 							return false
@@ -89,9 +89,9 @@ func TestIntegrationWorkspaceDisposal(t *testing.T) {
 					r.Spec.WorkspaceImage = "gitpod/workspace-full"
 				},
 				MockWsdaemon: func(t *testing.T, s *wsdaemon_mock.MockWorkspaceContentServiceServer) {
-					s.EXPECT().InitWorkspace(gomock.Any(), gomock.Any()).DoAndReturn(func(a, b interface{}) { time.Sleep(1 * time.Second) }).Return(nil, status.Error(codes.Internal, "fail intentionally"))
+					s.EXPECT().InitWorkspace(gomock.Any(), gomock.Any()).DoAndReturn(func(a, b any) { time.Sleep(1 * time.Second) }).Return(nil, status.Error(codes.Internal, "fail intentionally"))
 					s.EXPECT().WaitForInit(gomock.Any(), gomock.Any()).Return(&wsdaemon.WaitForInitResponse{}, nil).AnyTimes()
-					s.EXPECT().DisposeWorkspace(gomock.Any(), matches(func(a interface{}) bool {
+					s.EXPECT().DisposeWorkspace(gomock.Any(), matches(func(a any) bool {
 						_, ok := a.(*wsdaemon.DisposeWorkspaceRequest)
 						return ok //req.Backup == false
 					})).Return(&wsdaemon.DisposeWorkspaceResponse{}, nil).MinTimes(1)
@@ -117,7 +117,7 @@ func TestIntegrationWorkspaceDisposal(t *testing.T) {
 				MockWsdaemon: func(t *testing.T, s *wsdaemon_mock.MockWorkspaceContentServiceServer) {
 					initCall := s.EXPECT().InitWorkspace(gomock.Any(), gomock.Any()).Return(&wsdaemon.InitWorkspaceResponse{}, nil)
 					s.EXPECT().WaitForInit(gomock.Any(), gomock.Any()).Return(&wsdaemon.WaitForInitResponse{}, nil).MinTimes(1).After(initCall)
-					s.EXPECT().DisposeWorkspace(gomock.Any(), matches(func(a interface{}) bool {
+					s.EXPECT().DisposeWorkspace(gomock.Any(), matches(func(a any) bool {
 						req, ok := a.(*wsdaemon.DisposeWorkspaceRequest)
 						if !ok {
 							return false
@@ -163,7 +163,7 @@ func TestIntegrationWorkspaceDisposal(t *testing.T) {
 				MockWsdaemon: func(t *testing.T, s *wsdaemon_mock.MockWorkspaceContentServiceServer) {
 					initCall := s.EXPECT().InitWorkspace(gomock.Any(), gomock.Any()).Return(&wsdaemon.InitWorkspaceResponse{}, nil)
 					s.EXPECT().WaitForInit(gomock.Any(), gomock.Any()).Return(&wsdaemon.WaitForInitResponse{}, nil).MinTimes(1).After(initCall)
-					s.EXPECT().DisposeWorkspace(gomock.Any(), gomock.Any()).DoAndReturn(func(ctx context.Context, req interface{}) (resp *wsdaemon.DisposeWorkspaceRequest, err error) {
+					s.EXPECT().DisposeWorkspace(gomock.Any(), gomock.Any()).DoAndReturn(func(ctx context.Context, req any) (resp *wsdaemon.DisposeWorkspaceRequest, err error) {
 						return nil, context.DeadlineExceeded
 					}).MinTimes(wsdaemonMaxAttempts)
 				},
@@ -224,15 +224,15 @@ func TestIntegrationWorkspaceDisposal(t *testing.T) {
 	}
 }
 
-func matches(p func(interface{}) bool) gomock.Matcher {
+func matches(p func(any) bool) gomock.Matcher {
 	return &funcMatcher{p}
 }
 
 type funcMatcher struct {
-	P func(a interface{}) bool
+	P func(a any) bool
 }
 
-func (f *funcMatcher) Matches(a interface{}) bool {
+func (f *funcMatcher) Matches(a any) bool {
 	return f.P(a)
 }
 

--- a/components/ws-manager/pkg/manager/monitor_test.go
+++ b/components/ws-manager/pkg/manager/monitor_test.go
@@ -32,7 +32,7 @@ func TestActOnPodEvent(t *testing.T) {
 			res = strings.ReplaceAll(res, "/status_", "/actOnPodEvent_")
 			return res
 		},
-		Test: func(t *testing.T, input interface{}) interface{} {
+		Test: func(t *testing.T, input any) any {
 			fixture := input.(*workspaceObjects)
 			manager := Manager{
 				Clientset: fake.NewClientBuilder().Build(),
@@ -52,15 +52,15 @@ func TestActOnPodEvent(t *testing.T) {
 			}
 			return &result
 		},
-		Fixture: func() interface{} { return &workspaceObjects{} },
-		Gold:    func() interface{} { return &actOnPodEventResult{} },
+		Fixture: func() any { return &workspaceObjects{} },
+		Gold:    func() any { return &actOnPodEventResult{} },
 	}
 	test.Run()
 }
 
 type actRecord struct {
 	Func   string
-	Params map[string]interface{}
+	Params map[string]any
 }
 
 type actRecorder struct {
@@ -70,7 +70,7 @@ type actRecorder struct {
 func (r *actRecorder) waitForWorkspaceReady(ctx context.Context, pod *corev1.Pod) (err error) {
 	r.Records = append(r.Records, actRecord{
 		Func: "waitForWorkspaceReady",
-		Params: map[string]interface{}{
+		Params: map[string]any{
 			"pod": pod,
 		},
 	})
@@ -80,7 +80,7 @@ func (r *actRecorder) waitForWorkspaceReady(ctx context.Context, pod *corev1.Pod
 func (r *actRecorder) stopWorkspace(ctx context.Context, workspaceID string, gracePeriod time.Duration) (err error) {
 	r.Records = append(r.Records, actRecord{
 		Func: "stopWorkspace",
-		Params: map[string]interface{}{
+		Params: map[string]any{
 			"workspaceID": workspaceID,
 			"gracePeriod": gracePeriod,
 		},
@@ -91,7 +91,7 @@ func (r *actRecorder) stopWorkspace(ctx context.Context, workspaceID string, gra
 func (r *actRecorder) markWorkspace(ctx context.Context, workspaceID string, annotations ...*annotation) error {
 	r.Records = append(r.Records, actRecord{
 		Func: "markWorkspace",
-		Params: map[string]interface{}{
+		Params: map[string]any{
 			"workspaceID": workspaceID,
 			"annotations": annotations,
 		},
@@ -102,7 +102,7 @@ func (r *actRecorder) markWorkspace(ctx context.Context, workspaceID string, ann
 func (r *actRecorder) clearInitializerFromMap(podName string) {
 	r.Records = append(r.Records, actRecord{
 		Func: "clearInitializerFromMap",
-		Params: map[string]interface{}{
+		Params: map[string]any{
 			"podName": podName,
 		},
 	})
@@ -111,7 +111,7 @@ func (r *actRecorder) clearInitializerFromMap(podName string) {
 func (r *actRecorder) initializeWorkspaceContent(ctx context.Context, pod *corev1.Pod) (err error) {
 	r.Records = append(r.Records, actRecord{
 		Func: "initializeWorkspaceContent",
-		Params: map[string]interface{}{
+		Params: map[string]any{
 			"pod": pod,
 		},
 	})
@@ -121,7 +121,7 @@ func (r *actRecorder) initializeWorkspaceContent(ctx context.Context, pod *corev
 func (r *actRecorder) finalizeWorkspaceContent(ctx context.Context, wso *workspaceObjects) {
 	r.Records = append(r.Records, actRecord{
 		Func: "finalizeWorkspaceContent",
-		Params: map[string]interface{}{
+		Params: map[string]any{
 			"wso": wso,
 		},
 	})
@@ -130,7 +130,7 @@ func (r *actRecorder) finalizeWorkspaceContent(ctx context.Context, wso *workspa
 func (r *actRecorder) modifyFinalizer(ctx context.Context, workspaceID string, finalizer string, add bool) error {
 	r.Records = append(r.Records, actRecord{
 		Func: "modifyFinalizer",
-		Params: map[string]interface{}{
+		Params: map[string]any{
 			"workspaceID": workspaceID,
 			"finalizer":   finalizer,
 			"add":         add,
@@ -142,7 +142,7 @@ func (r *actRecorder) modifyFinalizer(ctx context.Context, workspaceID string, f
 func (r *actRecorder) deleteWorkspaceSecrets(ctx context.Context, podName string) error {
 	r.Records = append(r.Records, actRecord{
 		Func: "deleteWorkspaceSecrets",
-		Params: map[string]interface{}{
+		Params: map[string]any{
 			"podName": podName,
 		},
 	})

--- a/components/ws-manager/pkg/manager/status_test.go
+++ b/components/ws-manager/pkg/manager/status_test.go
@@ -38,7 +38,7 @@ func TestIsWorkspaceTimedout(t *testing.T) {
 	test := ctesting.FixtureTest{
 		T:    t,
 		Path: "testdata/timeout*.json",
-		Test: func(t *testing.T, input interface{}) interface{} {
+		Test: func(t *testing.T, input any) any {
 			fixture := input.(*fixture)
 			manager := Manager{
 				clock: clock.LogicalOnly(),
@@ -90,8 +90,8 @@ func TestIsWorkspaceTimedout(t *testing.T) {
 			}
 			return &result
 		},
-		Fixture: func() interface{} { return &fixture{} },
-		Gold:    func() interface{} { return &gold{} },
+		Fixture: func() any { return &fixture{} },
+		Gold:    func() any { return &gold{} },
 	}
 	test.Run()
 }
@@ -105,7 +105,7 @@ func TestGetWorkspaceStatusWithFixtures(t *testing.T) {
 	test := ctesting.FixtureTest{
 		T:    t,
 		Path: "testdata/status_*.json",
-		Test: func(t *testing.T, input interface{}) interface{} {
+		Test: func(t *testing.T, input any) any {
 			fixture := input.(*workspaceObjects)
 			manager := Manager{
 				clock: clock.LogicalOnly(),
@@ -118,8 +118,8 @@ func TestGetWorkspaceStatusWithFixtures(t *testing.T) {
 			}
 			return &result
 		},
-		Fixture: func() interface{} { return &workspaceObjects{} },
-		Gold:    func() interface{} { return &statusTestResult{} },
+		Fixture: func() any { return &workspaceObjects{} },
+		Gold:    func() any { return &statusTestResult{} },
 	}
 	test.Run()
 }

--- a/components/ws-proxy/pkg/proxy/config.go
+++ b/components/ws-proxy/pkg/proxy/config.go
@@ -186,7 +186,7 @@ func (c *BuiltinPagesConfig) Validate() error {
 func validateFileExists(addition string) validation.RuleFunc {
 	tpRoot := os.Getenv("TELEPRESENCE_ROOT")
 
-	return func(value interface{}) error {
+	return func(value any) error {
 		pth, ok := value.(string)
 		if !ok {
 			return xerrors.Errorf("validateFileExists: value must be a string")

--- a/components/ws-proxy/pkg/proxy/infoprovider.go
+++ b/components/ws-proxy/pkg/proxy/infoprovider.go
@@ -84,7 +84,7 @@ const (
 func NewRemoteWorkspaceInfoProvider(client client.Client, scheme *runtime.Scheme) *RemoteWorkspaceInfoProvider {
 	// create custom indexer for searches
 	indexers := cache.Indexers{
-		workspaceIndex: func(obj interface{}) ([]string, error) {
+		workspaceIndex: func(obj any) ([]string, error) {
 			if workspaceInfo, ok := obj.(*WorkspaceInfo); ok {
 				return []string{workspaceInfo.WorkspaceID}, nil
 			}

--- a/components/ws-proxy/pkg/proxy/routes_test.go
+++ b/components/ws-proxy/pkg/proxy/routes_test.go
@@ -133,7 +133,7 @@ func startTestTarget(t *testing.T, host, name string, checkedHost bool) *testTar
 			w.Header().Set("Content-Type", "text/plain; charset=utf-8")
 			w.WriteHeader(http.StatusOK)
 			format := "%s hit: %s\n"
-			args := []interface{}{name, r.URL.String()}
+			args := []any{name, r.URL.String()}
 			if checkedHost {
 				format += "host: %s\n"
 				args = append(args, r.Host)
@@ -782,7 +782,7 @@ func TestSSHGatewayRouter(t *testing.T) {
 			if resp.StatusCode != 200 {
 				t.Fatalf("status code should be 200, but got %d", resp.StatusCode)
 			}
-			var hostkeys []map[string]interface{}
+			var hostkeys []map[string]any
 			fmt.Println(string(body))
 			err = json.Unmarshal(body, &hostkeys)
 			if err != nil {

--- a/components/ws-proxy/pkg/sshproxy/forward.go
+++ b/components/ws-proxy/pkg/sshproxy/forward.go
@@ -93,7 +93,7 @@ func (s *Server) ChannelForward(ctx context.Context, session *Session, targetCon
 }
 
 func TrackIDECloseSignal(session *Session) {
-	propertics := make(map[string]interface{})
+	propertics := make(map[string]any)
 	propertics["workspaceId"] = session.WorkspaceID
 	propertics["instanceId"] = session.InstanceID
 	propertics["clientKind"] = "ssh"

--- a/components/ws-proxy/pkg/sshproxy/server.go
+++ b/components/ws-proxy/pkg/sshproxy/server.go
@@ -338,7 +338,7 @@ func (s *Server) TrackSSHConnection(wsInfo *p.WorkspaceInfo, phase string, err e
 	if wsInfo == nil {
 		return
 	}
-	propertics := make(map[string]interface{})
+	propertics := make(map[string]any)
 	propertics["workspaceId"] = wsInfo.WorkspaceID
 	propertics["instanceId"] = wsInfo.InstanceID
 	propertics["state"] = "success"

--- a/dev/gpctl/cmd/public-api.go
+++ b/dev/gpctl/cmd/public-api.go
@@ -50,7 +50,7 @@ func newPublicAPIConn() (*grpc.ClientConn, error) {
 
 	opts := []grpc.DialOption{
 		// attach token to requests to auth
-		grpc.WithUnaryInterceptor(func(ctx context.Context, method string, req, reply interface{}, cc *grpc.ClientConn, invoker grpc.UnaryInvoker, opts ...grpc.CallOption) error {
+		grpc.WithUnaryInterceptor(func(ctx context.Context, method string, req, reply any, cc *grpc.ClientConn, invoker grpc.UnaryInvoker, opts ...grpc.CallOption) error {
 			withAuth := metadata.AppendToOutgoingContext(ctx, "authorization", publicApiCmdOpts.token)
 			return invoker(withAuth, method, req, reply, cc, opts...)
 		}),

--- a/dev/gpctl/pkg/prettyprint/prettyprint.go
+++ b/dev/gpctl/pkg/prettyprint/prettyprint.go
@@ -33,7 +33,7 @@ const (
 	JSONFormat Format = "json"
 )
 
-type formatterFunc func(*Printer, interface{}) error
+type formatterFunc func(*Printer, any) error
 
 var formatter = map[Format]formatterFunc{
 	StringFormat:   formatString,
@@ -42,12 +42,12 @@ var formatter = map[Format]formatterFunc{
 	JSONPathFormat: formatJSONPath,
 }
 
-func formatString(pp *Printer, obj interface{}) error {
+func formatString(pp *Printer, obj any) error {
 	_, err := fmt.Fprintf(pp.Writer, "%s", obj)
 	return err
 }
 
-func formatJSONPath(pp *Printer, obj interface{}) error {
+func formatJSONPath(pp *Printer, obj any) error {
 	p := jsonpath.New("expr")
 	if err := p.Parse(pp.Template); err != nil {
 		return err
@@ -55,7 +55,7 @@ func formatJSONPath(pp *Printer, obj interface{}) error {
 	return p.Execute(pp.Writer, obj)
 }
 
-func formatTemplate(pp *Printer, obj interface{}) error {
+func formatTemplate(pp *Printer, obj any) error {
 	tmpl, err := template.New("prettyprint").Funcs(sprig.FuncMap()).Parse(pp.Template)
 	if err != nil {
 		return err
@@ -71,7 +71,7 @@ func formatTemplate(pp *Printer, obj interface{}) error {
 	return nil
 }
 
-func formatJSON(pp *Printer, obj interface{}) error {
+func formatJSON(pp *Printer, obj any) error {
 	enc := json.NewEncoder(pp.Writer)
 	enc.SetIndent("", "  ")
 	return enc.Encode(obj)
@@ -85,7 +85,7 @@ type Printer struct {
 }
 
 // Print pretty-prints the content
-func (pp *Printer) Print(obj interface{}) error {
+func (pp *Printer) Print(obj any) error {
 	formatter, ok := formatter[pp.Format]
 	if !ok {
 		return xerrors.Errorf("Unknown format: %s", pp.Format)

--- a/dev/gpctl/pkg/util/grpc.go
+++ b/dev/gpctl/pkg/util/grpc.go
@@ -21,8 +21,8 @@ var clientName = "gpctl:" + os.Getenv("USER") + "@" + os.Getenv("HOSTNAME") + os
 func clientInterceptor(
 	ctx context.Context,
 	method string,
-	req interface{},
-	reply interface{},
+	req any,
+	reply any,
 	cc *grpc.ClientConn,
 	invoker grpc.UnaryInvoker,
 	opts ...grpc.CallOption,

--- a/dev/preview/previewctl/pkg/k8s/service.go
+++ b/dev/preview/previewctl/pkg/k8s/service.go
@@ -46,7 +46,7 @@ func (c *Config) WaitProxySvcReady(ctx context.Context, namespace string, doneCh
 	defer close(stopCh)
 
 	svcInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{
-		AddFunc: func(obj interface{}) {
+		AddFunc: func(obj any) {
 			svc := obj.(*v1.Service)
 			if svc.Namespace == namespace && svc.Name == proxySvcName {
 				doneCh <- struct{}{}

--- a/dev/preview/previewctl/pkg/k8s/vm.go
+++ b/dev/preview/previewctl/pkg/k8s/vm.go
@@ -96,7 +96,7 @@ func (c *Config) WaitVMReady(ctx context.Context, name, namespace string, doneCh
 	vmInformer := kubeInformerFactory.ForResource(vmInstanceResource).Informer()
 
 	vmInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{
-		AddFunc: func(obj interface{}) {
+		AddFunc: func(obj any) {
 			res := obj.(*unstructured.Unstructured)
 			ip, err := parseVMInstanceIPAddress(res)
 			if err != nil && errors.Is(err, ErrGettingVMIpAddress) {
@@ -111,7 +111,7 @@ func (c *Config) WaitVMReady(ctx context.Context, name, namespace string, doneCh
 			doneCh <- struct{}{}
 		},
 		// We also watch for updates
-		UpdateFunc: func(oldObj interface{}, newObj interface{}) {
+		UpdateFunc: func(oldObj any, newObj any) {
 			res := newObj.(*unstructured.Unstructured)
 			ip, err := parseVMInstanceIPAddress(res)
 			if err != nil && errors.Is(err, ErrGettingVMIpAddress) {

--- a/dev/version-manifest/main.go
+++ b/dev/version-manifest/main.go
@@ -61,8 +61,8 @@ func produceManifest(out io.Writer, dir fs.FS) error {
 
 	// We need to deduplicate keys in the resulting yaml file. To this end, we first build up
 	// a map of maps and later print that map YAML style.
-	res := make(map[string]interface{})
-	comps := make(map[string]interface{})
+	res := make(map[string]any)
+	comps := make(map[string]any)
 	res["components"] = comps
 	for k, v := range versions {
 		var (
@@ -76,17 +76,17 @@ func produceManifest(out io.Writer, dir fs.FS) error {
 			}
 
 			if _, ok := m[seg]; !ok {
-				m[seg] = make(map[string]interface{})
+				m[seg] = make(map[string]any)
 			}
-			m = m[seg].(map[string]interface{})
+			m = m[seg].(map[string]any)
 		}
 	}
 
 	// It's not clear how to maintain a stable order of keys using the YAML serializer.
 	// If it were, we could just through this map at the YAML serializer and call it a day.
 	// Right now, we have to produce the YAML ourselves.
-	var print func(m map[string]interface{}, indent int) error
-	print = func(m map[string]interface{}, indent int) error {
+	var print func(m map[string]any, indent int) error
+	print = func(m map[string]any, indent int) error {
 		keys := make([]string, 0, len(m))
 		for v := range m {
 			keys = append(keys, v)
@@ -96,7 +96,7 @@ func produceManifest(out io.Writer, dir fs.FS) error {
 		for _, k := range keys {
 			v := m[k]
 			fmt.Fprintf(out, "%s%s:", strings.Repeat("  ", indent), k)
-			if c, ok := v.(map[string]interface{}); ok {
+			if c, ok := v.(map[string]any); ok {
 				fmt.Fprintln(out)
 				err := print(c, indent+1)
 				if err != nil {

--- a/install/installer/cmd/render.go
+++ b/install/installer/cmd/render.go
@@ -98,7 +98,7 @@ func saveYamlToFiles(dir string, yaml []string) error {
 	return nil
 }
 
-func loadConfig(cfgFN string) (rawCfg interface{}, cfgVersion string, cfg *configv1.Config, err error) {
+func loadConfig(cfgFN string) (rawCfg any, cfgVersion string, cfg *configv1.Config, err error) {
 	var overrideConfig string
 	// Update overrideConfig if cfgFN is not empty
 	switch cfgFN {

--- a/install/installer/cmd/validate_config.go
+++ b/install/installer/cmd/validate_config.go
@@ -40,7 +40,7 @@ var validateConfigCmd = &cobra.Command{
 
 // runConfigValidation this will run the validation and print any validation errors
 // It's silent if everything is fine
-func runConfigValidation(version string, cfg interface{}) error {
+func runConfigValidation(version string, cfg any) error {
 	apiVersion, err := config.LoadConfigVersion(version)
 	if err != nil {
 		return err

--- a/install/installer/pkg/common/common.go
+++ b/install/installer/pkg/common/common.go
@@ -601,7 +601,7 @@ func ThirdPartyContainerRepo(configRegistry string, thirdPartyRegistry string) s
 }
 
 // ToJSONString returns the serialized JSON string of an object
-func ToJSONString(input interface{}) ([]byte, error) {
+func ToJSONString(input any) ([]byte, error) {
 	return json.MarshalIndent(input, "", "  ")
 }
 

--- a/install/installer/pkg/components/proxy/configmap.go
+++ b/install/installer/pkg/components/proxy/configmap.go
@@ -58,7 +58,7 @@ type openVSXTpl struct {
 	RepoURL string
 }
 
-func renderTemplate(tpl []byte, values interface{}) (*string, error) {
+func renderTemplate(tpl []byte, values any) (*string, error) {
 	t, err := template.New("template").Parse(string(tpl))
 	if err != nil {
 		return nil, err

--- a/install/installer/pkg/config/loader.go
+++ b/install/installer/pkg/config/loader.go
@@ -19,7 +19,7 @@ const CurrentVersion = "v1"
 
 // NewDefaultConfig returns a new instance of the current config struct,
 // with all defaults filled in.
-func NewDefaultConfig() (interface{}, error) {
+func NewDefaultConfig() (any, error) {
 	v, ok := versions[CurrentVersion]
 	if !ok {
 		return nil, fmt.Errorf("current config version is invalid - this should never happen")
@@ -36,21 +36,21 @@ func NewDefaultConfig() (interface{}, error) {
 
 type ConfigVersion interface {
 	// Factory provides a new instance of the config struct
-	Factory() interface{}
+	Factory() any
 
 	// Defaults fills in the defaults for this version.
 	// obj is expected to be the return value of Factory()
-	Defaults(obj interface{}) error
+	Defaults(obj any) error
 
 	// LoadValidationFuncs loads the custom validation functions
 	LoadValidationFuncs(*validator.Validate) error
 
 	// ClusterValidation introduces configuration specific cluster validation checks
-	ClusterValidation(cfg interface{}) cluster.ValidationChecks
+	ClusterValidation(cfg any) cluster.ValidationChecks
 
 	// CheckDeprecated checks for deprecated config params.
 	// Returns key/value pair of deprecated params/values and any error messages (used for conflicting params)
-	CheckDeprecated(cfg interface{}) (map[string]interface{}, []string)
+	CheckDeprecated(cfg any) (map[string]any, []string)
 }
 
 // AddVersion adds a new version.
@@ -80,7 +80,7 @@ func LoadConfigVersion(version string) (ConfigVersion, error) {
 // Load takes a config string and overrides that onto the default
 // config for that version (passed in the config). If no config version
 // is passed, It overrides it onto the default CurrentVersion of the binary
-func Load(overrideConfig string, strict bool) (cfg interface{}, version string, err error) {
+func Load(overrideConfig string, strict bool) (cfg any, version string, err error) {
 	var overrideVS struct {
 		APIVersion string `json:"apiVersion"`
 	}
@@ -127,7 +127,7 @@ func Load(overrideConfig string, strict bool) (cfg interface{}, version string, 
 	return cfg, apiVersion, nil
 }
 
-func Marshal(version string, cfg interface{}) ([]byte, error) {
+func Marshal(version string, cfg any) ([]byte, error) {
 	if _, ok := versions[version]; !ok {
 		return nil, fmt.Errorf("unsupported API version: %s", version)
 	}

--- a/install/installer/pkg/config/v1/config.go
+++ b/install/installer/pkg/config/v1/config.go
@@ -24,7 +24,7 @@ func init() {
 
 type version struct{}
 
-func (v version) Factory() interface{} {
+func (v version) Factory() any {
 	return &Config{
 		AuthProviders: []ObjectRef{},
 		BlockNewUsers: BlockNewUsers{
@@ -33,7 +33,7 @@ func (v version) Factory() interface{} {
 		},
 	}
 }
-func (v version) Defaults(in interface{}) error {
+func (v version) Defaults(in any) error {
 	cfg, ok := in.(*Config)
 	if !ok {
 		return config.ErrInvalidType
@@ -74,8 +74,8 @@ func (v version) Defaults(in interface{}) error {
 	return nil
 }
 
-func (v version) CheckDeprecated(rawCfg interface{}) (map[string]interface{}, []string) {
-	warnings := make(map[string]interface{}, 0)
+func (v version) CheckDeprecated(rawCfg any) (map[string]any, []string) {
+	warnings := make(map[string]any, 0)
 	conflicts := make([]string, 0)
 	cfg := rawCfg.(*Config)
 

--- a/install/installer/pkg/config/v1/validation.go
+++ b/install/installer/pkg/config/v1/validation.go
@@ -82,7 +82,7 @@ func (v version) LoadValidationFuncs(validate *validator.Validate) error {
 }
 
 // ClusterValidation introduces configuration specific cluster validation checks
-func (v version) ClusterValidation(rcfg interface{}) cluster.ValidationChecks {
+func (v version) ClusterValidation(rcfg any) cluster.ValidationChecks {
 	cfg := rcfg.(*Config)
 
 	var res cluster.ValidationChecks

--- a/install/installer/pkg/config/validation.go
+++ b/install/installer/pkg/config/validation.go
@@ -19,7 +19,7 @@ type ValidationResult struct {
 	Fatal    []string `json:"fatal,omitempty"`
 }
 
-func Validate(version ConfigVersion, cfg interface{}) (r *ValidationResult, err error) {
+func Validate(version ConfigVersion, cfg any) (r *ValidationResult, err error) {
 	defer func() {
 		if r != nil {
 			r.Valid = len(r.Fatal) == 0

--- a/install/installer/pkg/helm/settings.go
+++ b/install/installer/pkg/helm/settings.go
@@ -60,7 +60,7 @@ func SettingsFactory(config *Config, chart string, vals *values.Options) Setting
 	return settings
 }
 
-func (settings *Settings) Write(format string, v ...interface{}) {
+func (settings *Settings) Write(format string, v ...any) {
 	format = fmt.Sprintf("[Gitpod] %s\n", format)
 	log.Output(2, fmt.Sprintf(format, v...))
 }

--- a/test/pkg/integration/agent.go
+++ b/test/pkg/integration/agent.go
@@ -19,7 +19,7 @@ import (
 
 // ServeAgent is the main entrypoint for agents. It establishes flags and starts an RPC server
 // on a port passed as flag.
-func ServeAgent(rcvr interface{}) {
+func ServeAgent(rcvr any) {
 	defaultPort, _ := strconv.Atoi(os.Getenv("AGENT_RPC_PORT"))
 	port := flag.Int("rpc-port", defaultPort, "the port on wich to run the RPC server on")
 	flag.Parse()

--- a/test/tests/ide/jetbrains/gateway_test.go
+++ b/test/tests/ide/jetbrains/gateway_test.go
@@ -157,7 +157,7 @@ func TestJetBrainsGatewayWorkspace(t *testing.T) {
 				t.Logf("trigger github action")
 				_, err = githubClient.Actions.CreateWorkflowDispatchEventByFileName(ctx, "gitpod-io", "gitpod", "jetbrains-integration-test.yml", github.CreateWorkflowDispatchEventRequest{
 					Ref: "main",
-					Inputs: map[string]interface{}{
+					Inputs: map[string]any{
 						"secret_gateway_link": gatewayLink,
 						"secret_access_token": oauthToken,
 						"secret_endpoint":     strings.TrimPrefix(nfo.LatestInstance.IdeURL, "https://"),


### PR DESCRIPTION
Rewrites `interface{}` to `any` using `gofmt`

[_Created by Sourcegraph batch change `christine/Go-upgrade-type`._](https://demo.sourcegraph.com/users/christine/batch-changes/Go-upgrade-type)